### PR TITLE
Fix universe actions

### DIFF
--- a/src/routes/admin/posts/[id]/edit/+page.svelte
+++ b/src/routes/admin/posts/[id]/edit/+page.svelte
@@ -367,10 +367,12 @@
 					onStatusChange={handleSave}
 					disabled={saving}
 					isLoading={saving}
-					primaryAction={status === 'published'
-						? { label: 'Save', status: 'published' }
-						: { label: 'Publish', status: 'published' }}
-					dropdownActions={[{ label: 'Save as Draft', status: 'draft', show: status !== 'draft' }]}
+					primaryAction={status === 'draft'
+						? { label: 'Save draft', status: 'draft' }
+						: { label: 'Save post', status: 'published' }}
+					dropdownActions={status === 'draft'
+						? [{ label: 'Publish', status: 'published' }]
+						: [{ label: 'Save as Draft', status: 'draft' }]}
 					viewUrl={slug ? `/universe/${slug}` : undefined}
 				/>
 			</div>


### PR DESCRIPTION
When editing a draft post, the primary action is now "Save draft" with "Publish" in the dropdown menu. When editing a published post, the primary action is "Save post" with "Save as Draft" in the dropdown.