### PR TITLE
Nudge play icon for optical centering

### DIFF
--- a/src/lib/components/Album.svelte
+++ b/src/lib/components/Album.svelte
@@ -229,6 +229,7 @@
 				display: flex;
 				align-items: center;
 				justify-content: center;
+				padding-left: 2px;
 				font-size: 24px;
 				transition: all $transition-medium ease;
 				backdrop-filter: blur(10px);
@@ -254,6 +255,7 @@
 
 				&.playing {
 					background: $accent-color;
+					padding-left: 0;
 				}
 			}
 


### PR DESCRIPTION
## Summary
- Adds 2px left padding to the preview button so the play triangle looks visually centered
- Resets padding when in playing state since the pause icon is symmetric

## Test plan
- [ ] Hover over an album with a preview — play icon should look centered
- [ ] Click to play — pause icon should also look centered