### PR TITLE
arch audit phase 2: reliability and perf fixes

### DIFF
--- a/prisma/migrations/20260420000000_add_composite_indexes/migration.sql
+++ b/prisma/migrations/20260420000000_add_composite_indexes/migration.sql
@@ -1,0 +1,5 @@
+-- CreateIndex
+CREATE INDEX "Post_status_postType_idx" ON "Post"("status", "postType");
+
+-- CreateIndex
+CREATE INDEX "Media_isPhotography_idx" ON "Media"("isPhotography");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,6 +60,7 @@ model Post {
   @@index([slug])
   @@index([status])
   @@index([postType])
+  @@index([status, postType])
 }
 
 model Album {
@@ -142,6 +143,8 @@ model Media {
   albums           AlbumMedia[]
   usage            MediaUsage[]
   photos           Photo[]
+
+  @@index([isPhotography])
 }
 
 model MediaUsage {
@@ -245,27 +248,27 @@ model Setting {
 }
 
 model GardenItem {
-  id           Int      @id @default(autoincrement())
-  category     String   @db.VarChar(50)
-  title        String   @db.VarChar(255)
-  slug         String   @db.VarChar(255)
-  creator      String?  @db.VarChar(255)
-  imageUrl       String?  @db.VarChar(500)
-  sourceImageUrl String?  @db.VarChar(500)
-  url            String?  @db.VarChar(500)
-  sourceId     String?  @db.VarChar(255)
-  metadata     Json?
-  summary      String?   @db.Text
-  date         DateTime? @db.Date
-  note         Json?
-  rating       Int?
-  isCurrent    Boolean  @default(false)
-  isFavorite   Boolean  @default(false)
-  status       String   @default("draft") @db.VarChar(50)
-  publishedAt  DateTime?
-  displayOrder Int      @default(0)
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  id             Int       @id @default(autoincrement())
+  category       String    @db.VarChar(50)
+  title          String    @db.VarChar(255)
+  slug           String    @db.VarChar(255)
+  creator        String?   @db.VarChar(255)
+  imageUrl       String?   @db.VarChar(500)
+  sourceImageUrl String?   @db.VarChar(500)
+  url            String?   @db.VarChar(500)
+  sourceId       String?   @db.VarChar(255)
+  metadata       Json?
+  summary        String?   @db.Text
+  date           DateTime? @db.Date
+  note           Json?
+  rating         Int?
+  isCurrent      Boolean   @default(false)
+  isFavorite     Boolean   @default(false)
+  status         String    @default("draft") @db.VarChar(50)
+  publishedAt    DateTime?
+  displayOrder   Int       @default(0)
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
 
   @@unique([category, slug])
   @@index([category])

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,4 +1,5 @@
 import type { Handle } from '@sveltejs/kit'
+import '$lib/server/env'
 
 // --- Rate limiter ---
 const attempts = new Map<string, { count: number; resetAt: number }>()

--- a/src/lib/server/admin/session.ts
+++ b/src/lib/server/admin/session.ts
@@ -1,6 +1,7 @@
 import { dev } from '$app/environment'
 import type { Cookies } from '@sveltejs/kit'
 import { createHmac, timingSafeEqual } from 'node:crypto'
+import { env } from '$lib/server/env'
 import type { SessionUser } from '$lib/types/session'
 
 const SESSION_COOKIE_NAME = 'admin_session'
@@ -11,16 +12,8 @@ interface SessionPayload {
 	exp: number
 }
 
-function sessionSecret(): string {
-	const secret = process.env.ADMIN_SESSION_SECRET
-	if (!secret) {
-		throw new Error('ADMIN_SESSION_SECRET environment variable is required')
-	}
-	return secret
-}
-
 function signPayload(payload: string): Buffer {
-	const hmac = createHmac('sha256', sessionSecret())
+	const hmac = createHmac('sha256', env.adminSessionSecret)
 	hmac.update(payload)
 	return hmac.digest()
 }
@@ -74,7 +67,7 @@ function parseToken(token: string): SessionPayload | null {
 }
 
 export function validateAdminPassword(password: string): SessionUser | null {
-	const expected = process.env.ADMIN_PASSWORD
+	const expected = env.adminPassword
 	if (!expected) {
 		if (dev) {
 			console.warn('ADMIN_PASSWORD not set — login disabled in dev')

--- a/src/lib/server/env.ts
+++ b/src/lib/server/env.ts
@@ -1,0 +1,37 @@
+import 'dotenv/config'
+import { dev } from '$app/environment'
+
+const REQUIRED = ['ADMIN_SESSION_SECRET', 'ADMIN_PASSWORD', 'REDIS_URL', 'DATABASE_URL'] as const
+
+type RequiredKey = (typeof REQUIRED)[number]
+
+const DEV_OPTIONAL = new Set<RequiredKey>(['ADMIN_PASSWORD', 'REDIS_URL'])
+
+function validate(): void {
+	const missing: string[] = []
+	for (const key of REQUIRED) {
+		if (!process.env[key]) {
+			if (dev && DEV_OPTIONAL.has(key)) {
+				console.warn(`[env] ${key} not set — falling back to dev default`)
+				continue
+			}
+			missing.push(key)
+		}
+	}
+	if (missing.length > 0) {
+		throw new Error(
+			`Missing required environment variables: ${missing.join(', ')}. ` +
+				'Set them before starting the server.'
+		)
+	}
+}
+
+validate()
+
+export const env = {
+	adminSessionSecret: process.env.ADMIN_SESSION_SECRET as string,
+	adminPassword: process.env.ADMIN_PASSWORD,
+	redisUrl: process.env.REDIS_URL ?? 'redis://localhost:6379',
+	databaseUrl: process.env.DATABASE_URL as string,
+	lastfmApiKey: process.env.LASTFM_API_KEY
+}

--- a/src/routes/api/posts/+server.ts
+++ b/src/routes/api/posts/+server.ts
@@ -61,7 +61,7 @@ export const GET: RequestHandler = async (event) => {
 			take: limit,
 			include: {
 				tags: {
-					include: {
+					select: {
 						tag: {
 							select: {
 								id: true,

--- a/src/routes/api/posts/[id]/+server.ts
+++ b/src/routes/api/posts/[id]/+server.ts
@@ -26,8 +26,15 @@ export const GET: RequestHandler = async (event) => {
 			where: { id },
 			include: {
 				tags: {
-					include: {
-						tag: true
+					select: {
+						tag: {
+							select: {
+								id: true,
+								name: true,
+								displayName: true,
+								slug: true
+							}
+						}
 					}
 				}
 			}

--- a/src/routes/api/redis-client.ts
+++ b/src/routes/api/redis-client.ts
@@ -1,6 +1,6 @@
-import 'dotenv/config'
 import { Redis } from 'ioredis'
+import { env } from '$lib/server/env'
 
-const redis = new Redis(process.env.REDIS_URL || 'redis://localhost:6379')
+const redis = new Redis(env.redisUrl)
 
 export default redis

--- a/src/routes/api/universe/+server.ts
+++ b/src/routes/api/universe/+server.ts
@@ -70,7 +70,7 @@ export const GET: RequestHandler = async (event) => {
 				publishedAt: true,
 				createdAt: true,
 				tags: {
-					include: {
+					select: {
 						tag: {
 							select: {
 								id: true,


### PR DESCRIPTION
## Summary

Phase 2 of the architecture audit — three self-contained reliability/perf fixes.

- **A-5** · Add `@@index([status, postType])` on `Post` and `@@index([isPhotography])` on `Media`. Covers the filter combos used by `/api/posts` list (status + type) and the `isPhotography` filter on Media. Migration `20260420000000_add_composite_indexes` included — run `prisma migrate deploy` to apply.
- **A-8** · New `src/lib/server/env.ts` validates `ADMIN_SESSION_SECRET`, `ADMIN_PASSWORD`, `REDIS_URL`, `DATABASE_URL` at import time. Boot fails fast in prod if any are missing; dev warns on `ADMIN_PASSWORD`/`REDIS_URL` and falls back. Wired into `hooks.server.ts`, `admin/session.ts`, and `redis-client.ts`.
- **A-11** · Replace `include: { tags: { include: { tag: … } } }` with nested `select` in `/api/posts`, `/api/posts/[id]`, and `/api/universe`. Skips the 4 unused `PostTag` join-row columns; detail endpoint also narrows Tag fields to `{id, name, displayName, slug}` (no consumer reads `description`/`createdAt`/`updatedAt`).

A-13 (script Prisma leaks) was audited — every script using Prisma already calls `$disconnect()` in a `finally`. No code change needed.

## Test plan

- [ ] `pnpm check` — baseline 116 errors / 9 warnings, no new ones introduced
- [ ] `pnpm exec prisma migrate deploy` applies the new indexes
- [ ] Boot with `ADMIN_SESSION_SECRET` unset → process exits with "Missing required environment variables"
- [ ] Posts list and detail responses still include `tags: [{ tag: {...} }]` shape (admin edit page depends on this)
- [ ] `EXPLAIN` on `SELECT * FROM "Post" WHERE status = 'published' AND "postType" = 'post'` uses `Post_status_postType_idx`