### PR TITLE
unify api error response shape

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -79,7 +79,7 @@ function requiresAdmin(pathname: string): boolean {
 
 function unauthorized(): Response {
 	return withSecurityHeaders(
-		new Response(JSON.stringify({ error: 'Unauthorized' }), {
+		new Response(JSON.stringify({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } }), {
 			status: 401,
 			headers: { 'Content-Type': 'application/json' }
 		})

--- a/src/lib/components/admin/AlbumForm.svelte
+++ b/src/lib/components/admin/AlbumForm.svelte
@@ -204,7 +204,7 @@
 			if (!response.ok) {
 				const errorData = await response.json()
 				throw new Error(
-					errorData.message || `Failed to ${mode === 'edit' ? 'save' : 'create'} album`
+					errorData.error?.message || `Failed to ${mode === 'edit' ? 'save' : 'create'} album`
 				)
 			}
 

--- a/src/lib/components/admin/AlbumSelector.svelte
+++ b/src/lib/components/admin/AlbumSelector.svelte
@@ -124,7 +124,7 @@
 
 			if (!response.ok) {
 				const errorData = await response.json()
-				throw new Error(errorData.message || 'Failed to create album')
+				throw new Error(errorData.error?.message || 'Failed to create album')
 			}
 
 			const newAlbum = await response.json()

--- a/src/lib/components/admin/GalleryUploader.svelte
+++ b/src/lib/components/admin/GalleryUploader.svelte
@@ -85,7 +85,7 @@
 
 			if (!response.ok) {
 				const errorData = await response.json()
-				throw new Error(errorData.error || `Upload failed for ${file.name}`)
+				throw new Error(errorData.error?.message || `Upload failed for ${file.name}`)
 			}
 
 			return await response.json()

--- a/src/lib/components/admin/ImageUploader.svelte
+++ b/src/lib/components/admin/ImageUploader.svelte
@@ -91,7 +91,7 @@
 
 		if (!response.ok) {
 			const errorData = await response.json()
-			throw new Error(errorData.error || 'Upload failed')
+			throw new Error(errorData.error?.message || 'Upload failed')
 		}
 
 		return await response.json()

--- a/src/lib/components/admin/MediaUploadModal.svelte
+++ b/src/lib/components/admin/MediaUploadModal.svelte
@@ -86,7 +86,10 @@
 
 				if (!response.ok) {
 					const error = await response.json()
-					uploadErrors = [...uploadErrors, `${file.name}: ${error.message || 'Upload failed'}`]
+					uploadErrors = [
+						...uploadErrors,
+						`${file.name}: ${error.error?.message || 'Upload failed'}`
+					]
 				} else {
 					successCount++
 					uploadProgress = { ...uploadProgress, [file.name]: 100 }

--- a/src/lib/server/api-utils.ts
+++ b/src/lib/server/api-utils.ts
@@ -1,5 +1,6 @@
 import type { RequestEvent } from '@sveltejs/kit'
 import { getSessionUser } from '$lib/server/admin/session'
+import { codeForStatus } from '$lib/server/error-codes'
 
 // Response helpers
 export function jsonResponse(data: unknown, status = 200): Response {
@@ -9,8 +10,12 @@ export function jsonResponse(data: unknown, status = 200): Response {
 	})
 }
 
-export function errorResponse(message: string, status = 400): Response {
-	return jsonResponse({ error: message }, status)
+export function errorResponse(message: string, status = 400, details?: unknown): Response {
+	const body: { error: { code: string; message: string; details?: unknown } } = {
+		error: { code: codeForStatus(status), message }
+	}
+	if (details !== undefined) body.error.details = details
+	return jsonResponse(body, status)
 }
 
 // Pagination helper

--- a/src/lib/server/error-codes.ts
+++ b/src/lib/server/error-codes.ts
@@ -1,0 +1,18 @@
+export const ERROR_CODES = {
+	400: 'BAD_REQUEST',
+	401: 'UNAUTHORIZED',
+	403: 'FORBIDDEN',
+	404: 'NOT_FOUND',
+	409: 'CONFLICT',
+	413: 'PAYLOAD_TOO_LARGE',
+	422: 'UNPROCESSABLE_ENTITY',
+	429: 'RATE_LIMITED',
+	500: 'INTERNAL_ERROR',
+	503: 'SERVICE_UNAVAILABLE'
+} as const
+
+export type ErrorCode = (typeof ERROR_CODES)[keyof typeof ERROR_CODES]
+
+export function codeForStatus(status: number): ErrorCode {
+	return ERROR_CODES[status as keyof typeof ERROR_CODES] ?? 'INTERNAL_ERROR'
+}

--- a/src/routes/admin/albums/+page.svelte
+++ b/src/routes/admin/albums/+page.svelte
@@ -227,7 +227,7 @@
 				goto('/admin/login')
 			} else {
 				const errorData = await response.json()
-				error = errorData.error || 'Failed to delete album'
+				error = errorData.error?.message || 'Failed to delete album'
 			}
 		} catch (err) {
 			console.error('Failed to delete album:', err)

--- a/src/routes/admin/media/upload/+page.svelte
+++ b/src/routes/admin/media/upload/+page.svelte
@@ -91,7 +91,10 @@
 
 				if (!response.ok) {
 					const error = await response.json()
-					uploadErrors = [...uploadErrors, `${file.name}: ${error.message || 'Upload failed'}`]
+					uploadErrors = [
+						...uploadErrors,
+						`${file.name}: ${error.error?.message || 'Upload failed'}`
+					]
 				} else {
 					successCount++
 					uploadProgress = { ...uploadProgress, [file.name]: 100 }


### PR DESCRIPTION
## Summary

Architecture audit A-1 — collapse the two competing API error shapes into one.

Every `errorResponse()` call now emits `{ error: { code, message, details? } }` where `code` is a symbolic name derived from the HTTP status (e.g. 401 → `UNAUTHORIZED`, 404 → `NOT_FOUND`, 500 → `INTERNAL_ERROR`). Clients get a consistent, self-describing shape and a stable place to attach validation details.

- **New**: `src/lib/server/error-codes.ts` — status → code map + `codeForStatus()` helper
- **Updated**: `errorResponse(message, status, details?)` emits the structured shape. Signature preserved — all ~300 route-side callers keep working unchanged.
- **Updated**: `hooks.server.ts` unauth response aligned to the same shape.
- **Updated**: 7 admin client fetch consumers now read `errorData.error?.message`. Three of them were reading `.error` as a string (will-break path). Four were silently broken (reading top-level `.message` that the old shape didn't emit either) — these now actually surface error messages.

Public pages that read `data.error` from `+page.server.ts` loaders are unaffected (loader-set strings, not API responses). Tags routes' bespoke `json({error: {code, message, field, details}})` calls already match the new shape. Success response bodies unchanged.

## Test plan

- [ ] `pnpm check` — baseline 116 errors / 9 warnings, no new ones
- [ ] `curl -I` unauthenticated `GET /api/admin/media-stats` → body is `{"error":{"code":"UNAUTHORIZED","message":"Unauthorized"}}`
- [ ] `POST /api/posts` with invalid JSON → `{"error":{"code":"BAD_REQUEST","message":"..."}}`
- [ ] Delete an album from the admin UI while logged out → status message shows "Unauthorized" (not `undefined`)
- [ ] Upload a file that fails server validation via `ImageUploader` → toast shows the actual error message
- [ ] Tag with reserved name → admin `TagInput` still shows the `TAG_NAME_RESERVED` message (tags route keeps its bespoke shape)