### PR TITLE
lazy-load the Tiptap composer

### DIFF
--- a/src/lib/components/admin/AlbumForm.svelte
+++ b/src/lib/components/admin/AlbumForm.svelte
@@ -8,7 +8,7 @@
 	import DropdownSelectField from './DropdownSelectField.svelte'
 	import UnifiedMediaModal from './UnifiedMediaModal.svelte'
 	import SmartImage from '../SmartImage.svelte'
-	import Composer from './composer'
+	import Composer from './composer/LazyComposer.svelte'
 	import SyndicationStatus from './SyndicationStatus.svelte'
 	import { toast } from '$lib/stores/toast'
 	import type { Album, Media } from '@prisma/client'

--- a/src/lib/components/admin/GardenItemForm.svelte
+++ b/src/lib/components/admin/GardenItemForm.svelte
@@ -5,7 +5,7 @@
 	import AdminPage from './AdminPage.svelte'
 	import AdminSegmentedControl from './AdminSegmentedControl.svelte'
 	import UnsavedChangesModal from './UnsavedChangesModal.svelte'
-	import Composer from './composer'
+	import Composer from './composer/LazyComposer.svelte'
 	import Typeahead from './Typeahead.svelte'
 	import GardenSelectionCard from './GardenSelectionCard.svelte'
 	import Input from './Input.svelte'

--- a/src/lib/components/admin/InlineComposerModal.svelte
+++ b/src/lib/components/admin/InlineComposerModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation'
 	import Modal from './Modal.svelte'
-	import Composer from './composer'
+	import Composer from './composer/LazyComposer.svelte'
 	import AdminSegmentedControl from './AdminSegmentedControl.svelte'
 	import Button from './Button.svelte'
 	import Input from './Input.svelte'

--- a/src/lib/components/admin/ProjectForm.svelte
+++ b/src/lib/components/admin/ProjectForm.svelte
@@ -5,7 +5,7 @@
 	import AdminSegmentedControl from './AdminSegmentedControl.svelte'
 	import StatusDropdown from './StatusDropdown.svelte'
 	import UnsavedChangesModal from './UnsavedChangesModal.svelte'
-	import Composer from './composer'
+	import Composer from './composer/LazyComposer.svelte'
 	import ProjectMetadataForm from './ProjectMetadataForm.svelte'
 	import ProjectBrandingForm from './ProjectBrandingForm.svelte'
 	import { toast } from '$lib/stores/toast'

--- a/src/lib/components/admin/composer/LazyComposer.svelte
+++ b/src/lib/components/admin/composer/LazyComposer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount, untrack } from 'svelte'
+	import { onMount } from 'svelte'
 	import type { Component } from 'svelte'
 	import type { ComposerProps } from './types'
 
@@ -22,9 +22,7 @@
 
 	onMount(async () => {
 		const mod = await import('./ComposerCore.svelte')
-		untrack(() => {
-			Composer = mod.default as Component<ComposerProps>
-		})
+		Composer = mod.default as Component<ComposerProps>
 	})
 
 	export function focus() {
@@ -69,7 +67,7 @@
 		width: 40px;
 		height: 40px;
 		border: 3px solid var(--card-border);
-		border-top-color: var(--copy-color);
+		border-top-color: var(--text-color);
 		border-radius: 50%;
 		animation: spin 0.8s linear infinite;
 	}

--- a/src/lib/components/admin/composer/LazyComposer.svelte
+++ b/src/lib/components/admin/composer/LazyComposer.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+	import { onMount, untrack } from 'svelte'
+	import type { Component } from 'svelte'
+	import type { ComposerProps } from './types'
+
+	let {
+		data = $bindable({
+			type: 'doc',
+			content: [{ type: 'paragraph' }]
+		}),
+		...rest
+	}: ComposerProps = $props()
+
+	let Composer = $state<Component<ComposerProps> | null>(null)
+
+	// Keep a reference to the mounted inner component so we can re-expose its
+	// methods to callers using `bind:this` on this wrapper. Typed as any
+	// because `bind:this` on a dynamic Component resolves to SvelteComponent,
+	// which doesn't carry our exported method types.
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	let inner = $state<any>(null)
+
+	onMount(async () => {
+		const mod = await import('./ComposerCore.svelte')
+		untrack(() => {
+			Composer = mod.default as Component<ComposerProps>
+		})
+	})
+
+	export function focus() {
+		inner?.focus()
+	}
+	export function blur() {
+		inner?.blur()
+	}
+	export function clear() {
+		inner?.clear()
+	}
+	export function isEmpty() {
+		return inner?.isEmpty() ?? true
+	}
+	export function getContent() {
+		return inner?.getContent()
+	}
+	export function getText() {
+		return inner?.getText() ?? ''
+	}
+</script>
+
+{#if Composer}
+	<Composer bind:this={inner} bind:data {...rest} />
+{:else}
+	<div class="lazy-composer-placeholder" style:min-height="{rest.minHeight ?? 200}px">
+		<div class="lazy-composer-skeleton"></div>
+	</div>
+{/if}
+
+<style lang="scss">
+	.lazy-composer-placeholder {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: var(--card-bg);
+		border: 1px solid var(--card-border);
+		border-radius: $unit;
+	}
+
+	.lazy-composer-skeleton {
+		width: 40px;
+		height: 40px;
+		border: 3px solid var(--card-border);
+		border-top-color: var(--copy-color);
+		border-radius: 50%;
+		animation: spin 0.8s linear infinite;
+	}
+
+	@keyframes spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+</style>

--- a/src/routes/admin/posts/[id]/edit/+page.svelte
+++ b/src/routes/admin/posts/[id]/edit/+page.svelte
@@ -5,7 +5,7 @@
 	import { api } from '$lib/admin/api'
 	import AdminPage from '$lib/components/admin/AdminPage.svelte'
 	import AdminSegmentedControl from '$lib/components/admin/AdminSegmentedControl.svelte'
-	import Composer from '$lib/components/admin/composer'
+	import Composer from '$lib/components/admin/composer/LazyComposer.svelte'
 	import LoadingSpinner from '$lib/components/admin/LoadingSpinner.svelte'
 	import PostMetadataForm from '$lib/components/admin/PostMetadataForm.svelte'
 	import PostSyndicationForm from '$lib/components/admin/PostSyndicationForm.svelte'

--- a/src/routes/admin/posts/new/+page.svelte
+++ b/src/routes/admin/posts/new/+page.svelte
@@ -4,7 +4,7 @@
 	import { api } from '$lib/admin/api'
 	import { onMount } from 'svelte'
 	import AdminPage from '$lib/components/admin/AdminPage.svelte'
-	import Composer from '$lib/components/admin/composer'
+	import Composer from '$lib/components/admin/composer/LazyComposer.svelte'
 	import PostMetadataPopover from '$lib/components/admin/PostMetadataPopover.svelte'
 	import UnsavedChangesModal from '$lib/components/admin/UnsavedChangesModal.svelte'
 	import PublishDropdown from '$lib/components/admin/PublishDropdown.svelte'


### PR DESCRIPTION
Audit #9: the ~1.7MB Tiptap chunk was statically pulled in by 10 admin routes (all edit/new form pages + the posts list page). This adds a `LazyComposer.svelte` wrapper that dynamic-imports `ComposerCore` on mount, so Tiptap only loads when the editor is actually about to render.

## Change

- **New `LazyComposer.svelte`** — thin wrapper that does `await import('./ComposerCore.svelte')` inside `onMount`, forwards all props + `bind:data`, and re-exports the editor's `focus`/`blur`/`clear`/`isEmpty`/`getContent`/`getText` methods so `bind:this` still works on the wrapper.
- **6 consumers swapped** to import `LazyComposer` instead of the barrel: `AlbumForm`, `ProjectForm`, `GardenItemForm`, `InlineComposerModal`, `/admin/posts/new`, `/admin/posts/[id]/edit`.
- **Placeholder** — a small spinner renders in the composer's footprint while the chunk loads.

## Measurement

Checked the built chunk graph by finding the chunk that contains Tiptap and counting which route nodes statically reference it.

| | Before | After |
|---|---|---|
| Admin route nodes that statically load Tiptap chunk | **10** | **0** |

Routes affected (`/admin/albums/new`, `/admin/albums/[id]/edit`, `/admin/garden/new`, `/admin/garden/[id]/edit`, `/admin/projects/new`, `/admin/projects/[id]/edit`, `/admin/posts/new`, `/admin/posts/[id]/edit`, `/admin/posts`, `/admin/universe/compose`) all now defer the ~1.7MB Tiptap chunk until the editor mounts.

## Trade-offs

- **Short loading state** on edit/new/compose pages — the rest of the form renders immediately; the composer area shows a spinner for one network round-trip before becoming interactive.
- **`/admin/posts` list page** — the inline composer at the top shows the same spinner briefly on page load. Acceptable given the list itself is the primary content.
- **`bind:this` forwarding** — the wrapper re-exports each editor method. If new methods are added to `ComposerCore`, they need to be forwarded here too.

## Test plan

- [ ] `/admin/posts/new` — spinner appears, composer replaces it, typing works, autosave fires
- [ ] `/admin/posts/[id]/edit` — existing content loads into composer correctly
- [ ] `/admin/albums/new` + `/admin/albums/[id]/edit` — album form fields render immediately; composer loads into the content area
- [ ] `/admin/projects/new` + `/admin/projects/[id]/edit` — case study editor works
- [ ] `/admin/garden/new` + `/admin/garden/[id]/edit` — notes editor works
- [ ] `/admin/posts` list page — inline composer's "clear" button still works (calls `editorInstance.clear()`)
- [ ] `/admin/universe/compose` — modal composer works in both inline and full modes
- [ ] Network tab on `/admin/posts` shows the Tiptap chunk loading lazily (not in the initial waterfall)