### PR TITLE
transactional post writes + safe cache keys

### DIFF
--- a/src/lib/server/cache-keys.ts
+++ b/src/lib/server/cache-keys.ts
@@ -1,0 +1,11 @@
+/**
+ * Encode a user-supplied string into a base64url segment safe for use inside a
+ * colon-separated Redis key. Prevents delimiter injection (e.g., a `search`
+ * term containing `:` that would collide with a structurally different key).
+ *
+ * Returns '-' for empty/nullish input so positional structure is preserved.
+ */
+export function safeKey(input: string | null | undefined): string {
+	if (!input) return '-'
+	return Buffer.from(input, 'utf8').toString('base64url')
+}

--- a/src/lib/server/media-usage.ts
+++ b/src/lib/server/media-usage.ts
@@ -1,4 +1,7 @@
+import type { Prisma } from '@prisma/client'
 import { prisma } from './database.js'
+
+type TxClient = Prisma.TransactionClient
 
 export interface MediaUsageReference {
 	mediaId: number
@@ -18,14 +21,14 @@ export interface MediaUsageDisplay {
 }
 
 /**
- * Track media usage for a piece of content
+ * Track media usage for a piece of content.
+ * Accepts an optional transaction client; when omitted, runs its own transaction.
  */
-export async function trackMediaUsage(references: MediaUsageReference[]) {
+export async function trackMediaUsage(references: MediaUsageReference[], tx?: TxClient) {
 	if (references.length === 0) return
 
-	// Use upsert to handle duplicates gracefully
-	const operations = references.map((ref) =>
-		prisma.mediaUsage.upsert({
+	const upsertFor = (client: TxClient | typeof prisma, ref: MediaUsageReference) =>
+		client.mediaUsage.upsert({
 			where: {
 				mediaId_contentType_contentId_fieldName: {
 					mediaId: ref.mediaId,
@@ -34,9 +37,7 @@ export async function trackMediaUsage(references: MediaUsageReference[]) {
 					fieldName: ref.fieldName
 				}
 			},
-			update: {
-				updatedAt: new Date()
-			},
+			update: { updatedAt: new Date() },
 			create: {
 				mediaId: ref.mediaId,
 				contentType: ref.contentType,
@@ -44,16 +45,28 @@ export async function trackMediaUsage(references: MediaUsageReference[]) {
 				fieldName: ref.fieldName
 			}
 		})
-	)
 
-	await prisma.$transaction(operations)
+	if (tx) {
+		for (const ref of references) {
+			await upsertFor(tx, ref)
+		}
+	} else {
+		await prisma.$transaction(references.map((ref) => upsertFor(prisma, ref)))
+	}
 }
 
 /**
- * Remove media usage tracking for a piece of content
+ * Remove media usage tracking for a piece of content.
+ * Accepts an optional transaction client.
  */
-export async function removeMediaUsage(contentType: string, contentId: number, fieldName?: string) {
-	await prisma.mediaUsage.deleteMany({
+export async function removeMediaUsage(
+	contentType: string,
+	contentId: number,
+	fieldName?: string,
+	tx?: TxClient
+) {
+	const client = tx ?? prisma
+	await client.mediaUsage.deleteMany({
 		where: {
 			contentType,
 			contentId,

--- a/src/routes/api/admin/garden/search/books/+server.ts
+++ b/src/routes/api/admin/garden/search/books/+server.ts
@@ -2,6 +2,7 @@ import redis from '../../../../redis-client'
 
 import type { RequestHandler } from './$types'
 import { jsonResponse, errorResponse } from '$lib/server/api-utils'
+import { safeKey } from '$lib/server/cache-keys'
 
 const CACHE_TTL = 60 * 60 // 1 hour
 const OPENLIBRARY_BASE = 'https://openlibrary.org'
@@ -25,7 +26,7 @@ export const GET: RequestHandler = async (event) => {
 
 	const limit = Math.min(10, Math.max(1, parseInt(event.url.searchParams.get('limit') || '5')))
 
-	const cacheKey = `openlibrary:search:${query.toLowerCase()}`
+	const cacheKey = `openlibrary:search:${safeKey(query.toLowerCase())}`
 	const cachedData = await redis.get(cacheKey)
 	if (cachedData) {
 		return jsonResponse({ results: JSON.parse(cachedData) })

--- a/src/routes/api/admin/garden/search/games/+server.ts
+++ b/src/routes/api/admin/garden/search/games/+server.ts
@@ -3,6 +3,7 @@ import redis from '../../../../redis-client'
 
 import type { RequestHandler } from './$types'
 import { jsonResponse, errorResponse } from '$lib/server/api-utils'
+import { safeKey } from '$lib/server/cache-keys'
 
 const CACHE_TTL = 60 * 60 // 1 hour
 const TOKEN_CACHE_KEY = 'igdb:access_token'
@@ -40,7 +41,7 @@ export const GET: RequestHandler = async (event) => {
 
 	const limit = Math.min(10, Math.max(1, parseInt(event.url.searchParams.get('limit') || '5')))
 
-	const cacheKey = `igdb:search:${query.toLowerCase()}`
+	const cacheKey = `igdb:search:${safeKey(query.toLowerCase())}`
 	const cachedData = await redis.get(cacheKey)
 	if (cachedData) {
 		return jsonResponse({ results: JSON.parse(cachedData) })

--- a/src/routes/api/admin/garden/search/manga/+server.ts
+++ b/src/routes/api/admin/garden/search/manga/+server.ts
@@ -2,6 +2,7 @@ import redis from '../../../../redis-client'
 
 import type { RequestHandler } from './$types'
 import { jsonResponse, errorResponse } from '$lib/server/api-utils'
+import { safeKey } from '$lib/server/cache-keys'
 
 const CACHE_TTL = 60 * 60 // 1 hour
 const ANILIST_URL = 'https://graphql.anilist.co'
@@ -46,7 +47,7 @@ export const GET: RequestHandler = async (event) => {
 
 	const limit = Math.min(10, Math.max(1, parseInt(event.url.searchParams.get('limit') || '5')))
 
-	const cacheKey = `anilist:search:${query.toLowerCase()}`
+	const cacheKey = `anilist:search:${safeKey(query.toLowerCase())}`
 	const cachedData = await redis.get(cacheKey)
 	if (cachedData) {
 		return jsonResponse({ results: JSON.parse(cachedData) })

--- a/src/routes/api/admin/garden/search/movies/+server.ts
+++ b/src/routes/api/admin/garden/search/movies/+server.ts
@@ -2,6 +2,7 @@ import redis from '../../../../redis-client'
 
 import type { RequestHandler } from './$types'
 import { jsonResponse, errorResponse } from '$lib/server/api-utils'
+import { safeKey } from '$lib/server/cache-keys'
 
 const CACHE_TTL = 60 * 60 // 1 hour
 const TMDB_BASE = 'https://api.themoviedb.org/3'
@@ -43,7 +44,7 @@ export const GET: RequestHandler = async (event) => {
 
 	const limit = Math.min(10, Math.max(1, parseInt(event.url.searchParams.get('limit') || '5')))
 
-	const cacheKey = `tmdb:search:${query.toLowerCase()}`
+	const cacheKey = `tmdb:search:${safeKey(query.toLowerCase())}`
 	const cachedData = await redis.get(cacheKey)
 	if (cachedData) {
 		return jsonResponse({ results: JSON.parse(cachedData) })

--- a/src/routes/api/admin/garden/search/music/+server.ts
+++ b/src/routes/api/admin/garden/search/music/+server.ts
@@ -4,6 +4,7 @@ import { getArtworkUrl } from '$lib/types/apple-music'
 
 import type { RequestHandler } from './$types'
 import { jsonResponse, errorResponse } from '$lib/server/api-utils'
+import { safeKey } from '$lib/server/cache-keys'
 
 const CACHE_TTL = 60 * 60 // 1 hour
 
@@ -15,7 +16,7 @@ export const GET: RequestHandler = async (event) => {
 
 	const limit = Math.min(10, Math.max(1, parseInt(event.url.searchParams.get('limit') || '5')))
 
-	const cacheKey = `apple-music:search:${query.toLowerCase()}`
+	const cacheKey = `apple-music:search:${safeKey(query.toLowerCase())}`
 	const cachedData = await redis.get(cacheKey)
 	if (cachedData) {
 		return jsonResponse({ results: JSON.parse(cachedData) })

--- a/src/routes/api/admin/garden/search/tv/+server.ts
+++ b/src/routes/api/admin/garden/search/tv/+server.ts
@@ -2,6 +2,7 @@ import redis from '../../../../redis-client'
 
 import type { RequestHandler } from './$types'
 import { jsonResponse, errorResponse } from '$lib/server/api-utils'
+import { safeKey } from '$lib/server/cache-keys'
 
 const CACHE_TTL = 60 * 60 // 1 hour
 const TVDB_BASE = 'https://api4.thetvdb.com/v4'
@@ -61,7 +62,7 @@ export const GET: RequestHandler = async (event) => {
 
 	const limit = Math.min(10, Math.max(1, parseInt(event.url.searchParams.get('limit') || '5')))
 
-	const cacheKey = `tvdb:search:${query.toLowerCase()}`
+	const cacheKey = `tvdb:search:${safeKey(query.toLowerCase())}`
 	const cachedData = await redis.get(cacheKey)
 	if (cachedData) {
 		return jsonResponse({ results: JSON.parse(cachedData) })

--- a/src/routes/api/og-metadata/+server.ts
+++ b/src/routes/api/og-metadata/+server.ts
@@ -1,6 +1,7 @@
 import { json } from '@sveltejs/kit'
 import type { RequestHandler } from './$types'
 import redis from '../redis-client'
+import { safeKey } from '$lib/server/cache-keys'
 
 export const GET: RequestHandler = async ({ url }) => {
 	const targetUrl = url.searchParams.get('url')
@@ -12,7 +13,7 @@ export const GET: RequestHandler = async ({ url }) => {
 
 	try {
 		// Check cache first (unless force refresh is requested)
-		const cacheKey = `og-metadata:${targetUrl}`
+		const cacheKey = `og-metadata:${safeKey(targetUrl)}`
 
 		if (!forceRefresh) {
 			const cached = await redis.get(cacheKey)
@@ -181,7 +182,7 @@ export const POST: RequestHandler = async ({ request }) => {
 
 	try {
 		// Check cache first - using same cache key format
-		const cacheKey = `og-metadata:${targetUrl}`
+		const cacheKey = `og-metadata:${safeKey(targetUrl)}`
 		const cached = await redis.get(cacheKey)
 
 		if (cached) {

--- a/src/routes/api/posts/+server.ts
+++ b/src/routes/api/posts/+server.ts
@@ -122,33 +122,33 @@ export const POST: RequestHandler = async (event) => {
 			featuredImageId = data.attachedPhotos[0]
 		}
 
-		const post = await prisma.post.create({
-			data: {
-				title: data.title,
-				slug: data.slug,
-				postType: data.type,
-				status: data.status,
-				content: data.content,
-				excerpt: data.excerpt || null,
-				syndicationText: data.syndicationText || null,
-				featuredImage: featuredImageId,
-				syndicateBluesky: data.syndicateBluesky ?? true,
-				syndicateMastodon: data.syndicateMastodon ?? true,
-				attachments:
-					data.attachedPhotos && data.attachedPhotos.length > 0 ? data.attachedPhotos : null,
-				publishedAt: data.publishedAt,
-				tags:
-					data.tagIds && Array.isArray(data.tagIds) && data.tagIds.length > 0
-						? {
-								create: data.tagIds.map((tagId: number) => ({
-									tag: { connect: { id: tagId } }
-								}))
-							}
-						: undefined
-			}
-		})
+		const post = await prisma.$transaction(async (tx) => {
+			const created = await tx.post.create({
+				data: {
+					title: data.title,
+					slug: data.slug,
+					postType: data.type,
+					status: data.status,
+					content: data.content,
+					excerpt: data.excerpt || null,
+					syndicationText: data.syndicationText || null,
+					featuredImage: featuredImageId,
+					syndicateBluesky: data.syndicateBluesky ?? true,
+					syndicateMastodon: data.syndicateMastodon ?? true,
+					attachments:
+						data.attachedPhotos && data.attachedPhotos.length > 0 ? data.attachedPhotos : null,
+					publishedAt: data.publishedAt,
+					tags:
+						data.tagIds && Array.isArray(data.tagIds) && data.tagIds.length > 0
+							? {
+									create: data.tagIds.map((tagId: number) => ({
+										tag: { connect: { id: tagId } }
+									}))
+								}
+							: undefined
+				}
+			})
 
-		try {
 			const usageReferences: MediaUsageReference[] = []
 
 			const featuredImageIds = extractMediaIds({ featuredImage: featuredImageId }, 'featuredImage')
@@ -156,7 +156,7 @@ export const POST: RequestHandler = async (event) => {
 				usageReferences.push({
 					mediaId,
 					contentType: 'post',
-					contentId: post.id,
+					contentId: created.id,
 					fieldName: 'featuredImage'
 				})
 			})
@@ -166,7 +166,7 @@ export const POST: RequestHandler = async (event) => {
 					usageReferences.push({
 						mediaId,
 						contentType: 'post',
-						contentId: post.id,
+						contentId: created.id,
 						fieldName: 'attachments'
 					})
 				})
@@ -177,7 +177,7 @@ export const POST: RequestHandler = async (event) => {
 					usageReferences.push({
 						mediaId,
 						contentType: 'post',
-						contentId: post.id,
+						contentId: created.id,
 						fieldName: 'gallery'
 					})
 				})
@@ -188,17 +188,15 @@ export const POST: RequestHandler = async (event) => {
 				usageReferences.push({
 					mediaId,
 					contentType: 'post',
-					contentId: post.id,
+					contentId: created.id,
 					fieldName: 'content'
 				})
 			})
 
-			if (usageReferences.length > 0) {
-				await trackMediaUsage(usageReferences)
-			}
-		} catch (_error) {
-			logger.warn('Failed to track media usage for post', { postId: post.id })
-		}
+			await trackMediaUsage(usageReferences, tx)
+
+			return created
+		})
 
 		logger.info('Post created', { id: post.id, title: post.title })
 

--- a/src/routes/api/posts/[id]/+server.ts
+++ b/src/routes/api/posts/[id]/+server.ts
@@ -100,32 +100,32 @@ export const PUT: RequestHandler = async (event) => {
 			}
 		}
 
-		const post = await prisma.post.update({
-			where: { id },
-			data: {
-				title: data.title,
-				slug: data.slug,
-				postType: data.type,
-				status: data.status,
-				content: data.content,
-				excerpt: data.excerpt ?? undefined,
-				syndicationText: data.syndicationText ?? undefined,
-				featuredImage: featuredImageId,
-				syndicateBluesky: data.syndicateBluesky ?? undefined,
-				syndicateMastodon: data.syndicateMastodon ?? undefined,
-				appendLink: data.appendLink ?? undefined,
-				attachments:
-					data.attachedPhotos && data.attachedPhotos.length > 0 ? data.attachedPhotos : null,
-				publishedAt: data.publishedAt,
-				...tagUpdate
-			}
-		})
+		const post = await prisma.$transaction(async (tx) => {
+			const updated = await tx.post.update({
+				where: { id },
+				data: {
+					title: data.title,
+					slug: data.slug,
+					postType: data.type,
+					status: data.status,
+					content: data.content,
+					excerpt: data.excerpt ?? undefined,
+					syndicationText: data.syndicationText ?? undefined,
+					featuredImage: featuredImageId,
+					syndicateBluesky: data.syndicateBluesky ?? undefined,
+					syndicateMastodon: data.syndicateMastodon ?? undefined,
+					appendLink: data.appendLink ?? undefined,
+					attachments:
+						data.attachedPhotos && data.attachedPhotos.length > 0 ? data.attachedPhotos : null,
+					publishedAt: data.publishedAt,
+					...tagUpdate
+				}
+			})
 
-		try {
-			await removeMediaUsage('post', id)
+			await removeMediaUsage('post', id, undefined, tx)
+
 			const usageReferences: MediaUsageReference[] = []
-
-			const featuredImageIds = extractMediaIds(post, 'featuredImage')
+			const featuredImageIds = extractMediaIds(updated, 'featuredImage')
 			featuredImageIds.forEach((mediaId) => {
 				usageReferences.push({
 					mediaId,
@@ -135,7 +135,7 @@ export const PUT: RequestHandler = async (event) => {
 				})
 			})
 
-			const attachmentIds = extractMediaIds(post, 'attachments')
+			const attachmentIds = extractMediaIds(updated, 'attachments')
 			attachmentIds.forEach((mediaId) => {
 				usageReferences.push({
 					mediaId,
@@ -145,7 +145,7 @@ export const PUT: RequestHandler = async (event) => {
 				})
 			})
 
-			const contentIds = extractMediaIds(post, 'content')
+			const contentIds = extractMediaIds(updated, 'content')
 			contentIds.forEach((mediaId) => {
 				usageReferences.push({
 					mediaId,
@@ -155,12 +155,10 @@ export const PUT: RequestHandler = async (event) => {
 				})
 			})
 
-			if (usageReferences.length > 0) {
-				await trackMediaUsage(usageReferences)
-			}
-		} catch (_error) {
-			logger.warn('Failed to update media usage for post', { postId: id })
-		}
+			await trackMediaUsage(usageReferences, tx)
+
+			return updated
+		})
 
 		logger.info('Post updated', { id })
 
@@ -256,9 +254,9 @@ export const DELETE: RequestHandler = async (event) => {
 			return errorResponse('Invalid post ID', 400)
 		}
 
-		await removeMediaUsage('post', id)
-		await prisma.post.delete({
-			where: { id }
+		await prisma.$transaction(async (tx) => {
+			await removeMediaUsage('post', id, undefined, tx)
+			await tx.post.delete({ where: { id } })
 		})
 
 		logger.info('Post deleted', { id })

--- a/src/routes/api/tags/+server.ts
+++ b/src/routes/api/tags/+server.ts
@@ -2,6 +2,7 @@ import type { RequestHandler } from './$types'
 import { json } from '@sveltejs/kit'
 import redis from '../redis-client'
 import { checkAdminAuth, errorResponse } from '$lib/server/api-utils'
+import { safeKey } from '$lib/server/cache-keys'
 import { createTag, listTags } from '$lib/server/tags/operations'
 import { createTagSchema } from '$lib/server/tags/schemas'
 
@@ -25,7 +26,7 @@ export const GET: RequestHandler = async ({ url }) => {
 
 	try {
 		// Try cache first
-		const cacheKey = `tags:list:${page}:${limit}:${sort}:${order}:${search ?? ''}`
+		const cacheKey = `tags:list:${page}:${limit}:${sort}:${order}:${safeKey(search)}`
 		const cached = await redis.get(cacheKey)
 
 		if (cached) {

--- a/src/routes/api/tags/suggest/+server.ts
+++ b/src/routes/api/tags/suggest/+server.ts
@@ -3,6 +3,7 @@ import { json } from '@sveltejs/kit'
 import redis from '../../redis-client'
 import { errorResponse } from '$lib/server/api-utils'
 import { suggestTags } from '$lib/server/tags/operations'
+import { safeKey } from '$lib/server/cache-keys'
 
 /**
  * GET /api/tags/suggest
@@ -22,7 +23,7 @@ export const GET: RequestHandler = async ({ url }) => {
 
 	try {
 		// Cache suggestions for 2 minutes
-		const cacheKey = `tags:suggest:${query}:${limit}`
+		const cacheKey = `tags:suggest:${safeKey(query)}:${limit}`
 		const cached = await redis.get(cacheKey)
 
 		if (cached) {


### PR DESCRIPTION
## Summary

Architecture audit A-6 and A-7 — two isolated integrity/security fixes.

### A-6 · Transactional post writes

`POST /api/posts`, `PUT /api/posts/[id]`, and `DELETE /api/posts/[id]` all did multi-step writes (post row + media-usage bookkeeping) without a transaction, with the media-usage block wrapped in a silent `try/catch` that warned and continued. The failure mode was exactly what A-6 flags: post updated, media usage left stale — orphaned `MediaUsage` rows.

Now wrapped in `prisma.$transaction`:
- `trackMediaUsage()` / `removeMediaUsage()` accept an optional `Prisma.TransactionClient`
- Post create/update/delete handlers pass the tx through so all writes commit atomically
- Silent catch removed — media-usage failures now roll back the post write (this is the intended behavior; the previous catch was the bug)

### A-7 · Redis cache key escaping

User-supplied query params were concatenated directly into Redis keys (e.g. \`tags:list:\${search}\`). A search term containing \`:\` could collide with a structurally different key, poisoning the cache or breaking wildcard invalidation (\`redis.keys('tags:list:*')\`).

- New \`src/lib/server/cache-keys.ts\` with \`safeKey()\` — base64url-encodes any user-supplied segment
- Applied to the public \`/api/og-metadata\` (highest attack surface — unauthenticated, URL param), \`/api/tags\` search, \`/api/tags/suggest\` query, and all 6 \`/api/admin/garden/search/*\` routes
- Key prefixes/structure preserved so wildcard patterns keep working

## Test plan

- [ ] \`pnpm check\` — baseline 116 errors / 9 warnings, no new ones
- [ ] Edit a post with attachments → verify DB: post row updated AND \`MediaUsage\` rows match the new attachment set
- [ ] Force a media-usage failure (e.g. temporarily break the upsert call) → post row should NOT update
- [ ] Delete a post → \`MediaUsage\` rows gone in same transaction
- [ ] Search tags with \`?search=foo:bar:baz\` → no Redis key collision (inspect \`redis-cli KEYS 'tags:list:*'\` — final segment is base64url)
- [ ] \`/api/og-metadata?url=https://example.com\` still caches and returns consistently