### PR TITLE
align delete status codes + document mutation contract

### DIFF
--- a/src/lib/server/admin/authenticated-fetch.ts
+++ b/src/lib/server/admin/authenticated-fetch.ts
@@ -33,10 +33,14 @@ export async function adminFetch(
 		let detail: string | undefined
 		try {
 			const json = await response.clone().json()
-			detail =
-				typeof json === 'object' && json !== null && 'error' in json
-					? String(json.error)
-					: undefined
+			if (typeof json === 'object' && json !== null && 'error' in json) {
+				const err = (json as { error: unknown }).error
+				if (typeof err === 'string') detail = err
+				else if (err && typeof err === 'object' && 'message' in err) {
+					const msg = (err as { message: unknown }).message
+					if (typeof msg === 'string') detail = msg
+				}
+			}
 		} catch {
 			try {
 				detail = await response.clone().text()

--- a/src/lib/server/api-utils.ts
+++ b/src/lib/server/api-utils.ts
@@ -2,6 +2,24 @@ import type { RequestEvent } from '@sveltejs/kit'
 import { getSessionUser } from '$lib/server/admin/session'
 import { codeForStatus } from '$lib/server/error-codes'
 
+/**
+ * Mutation response contract
+ * -----------------------------------------------------------------------------
+ * API routes (`/api/*` — returns a Response):
+ *   • success:      return jsonResponse(data, status?)
+ *                   DELETE success: return jsonResponse({ success: true })
+ *   • error:        return errorResponse(message, status, details?)
+ *                   body is always { error: { code, message, details? } }
+ *
+ * Form actions (`actions` in +page.server.ts):
+ *   • success:      throw redirect(303, path)  — never return a body alongside
+ *   • error:        return fail(status, { message })
+ *
+ * Never mix shapes: form actions don't emit `errorResponse`, API routes don't
+ * call `fail()`. See A-14/A-15 in the architecture audit for context.
+ * -----------------------------------------------------------------------------
+ */
+
 // Response helpers
 export function jsonResponse(data: unknown, status = 200): Response {
 	return new Response(JSON.stringify(data), {

--- a/src/routes/api/admin/garden/[id]/+server.ts
+++ b/src/routes/api/admin/garden/[id]/+server.ts
@@ -174,7 +174,7 @@ export const DELETE: RequestHandler = async (event) => {
 
 		await prisma.gardenItem.delete({ where: { id } })
 		logger.info('Garden item deleted', { id })
-		return new Response(null, { status: 204 })
+		return jsonResponse({ success: true })
 	} catch (error) {
 		logger.error('Failed to delete garden item', error as Error)
 		return errorResponse('Failed to delete garden item', 500)

--- a/src/routes/api/albums/[id]/+server.ts
+++ b/src/routes/api/albums/[id]/+server.ts
@@ -198,7 +198,7 @@ export const DELETE: RequestHandler = async (event) => {
 
 		logger.info('Album deleted', { id, slug: album.slug, mediaUnlinked: album._count.media })
 
-		return new Response(null, { status: 204 })
+		return jsonResponse({ success: true })
 	} catch (error) {
 		logger.error('Failed to delete album', error as Error)
 		return errorResponse('Failed to delete album', 500)

--- a/src/routes/api/albums/[id]/photos/+server.ts
+++ b/src/routes/api/albums/[id]/photos/+server.ts
@@ -267,7 +267,7 @@ export const DELETE: RequestHandler = async (event) => {
 			albumId: albumId
 		})
 
-		return new Response(null, { status: 204 })
+		return jsonResponse({ success: true })
 	} catch (error) {
 		logger.error('Failed to remove media from album', error as Error)
 		return errorResponse('Failed to remove media from album', 500)

--- a/src/routes/api/media/[id]/+server.ts
+++ b/src/routes/api/media/[id]/+server.ts
@@ -148,7 +148,7 @@ export const DELETE: RequestHandler = async (event) => {
 
 		logger.info('Media deleted', { id, filename: media.filename })
 
-		return new Response(null, { status: 204 })
+		return jsonResponse({ success: true })
 	} catch (error) {
 		logger.error('Failed to delete media', error as Error)
 		return errorResponse('Failed to delete media', 500)

--- a/src/routes/api/photos/[id]/+server.ts
+++ b/src/routes/api/photos/[id]/+server.ts
@@ -132,7 +132,7 @@ export const DELETE: RequestHandler = async (event) => {
 
 		logger.info('Media removed from photography', { mediaId: id })
 
-		return new Response(null, { status: 204 })
+		return jsonResponse({ success: true })
 	} catch (error) {
 		logger.error('Failed to remove photo', error as Error)
 		return errorResponse('Failed to remove photo', 500)

--- a/src/routes/api/posts/[id]/+server.ts
+++ b/src/routes/api/posts/[id]/+server.ts
@@ -260,7 +260,7 @@ export const DELETE: RequestHandler = async (event) => {
 		})
 
 		logger.info('Post deleted', { id })
-		return new Response(null, { status: 204 })
+		return jsonResponse({ success: true })
 	} catch (error) {
 		logger.error('Failed to delete post', error as Error)
 		return errorResponse('Failed to delete post', 500)

--- a/src/routes/api/projects/[id]/+server.ts
+++ b/src/routes/api/projects/[id]/+server.ts
@@ -390,7 +390,7 @@ export const DELETE: RequestHandler = async (event) => {
 
 		logger.info('Project deleted', { id })
 
-		return new Response(null, { status: 204 })
+		return jsonResponse({ success: true })
 	} catch (error) {
 		logger.error('Failed to delete project', error as Error)
 		return errorResponse('Failed to delete project', 500)

--- a/src/routes/api/tags/[id]/+server.ts
+++ b/src/routes/api/tags/[id]/+server.ts
@@ -172,7 +172,7 @@ export const DELETE: RequestHandler = async (event) => {
 		// Invalidate all caches (related posts depend on tags)
 		await redis.flushdb()
 
-		return new Response(null, { status: 204 })
+		return json({ success: true })
 	} catch (error) {
 		if (error instanceof Error && error.message.includes('Record to delete does not exist')) {
 			return json(


### PR DESCRIPTION
## Summary

Architecture audit A-14 and A-15 — tighten the mutation response contract and remove the 204-vs-200 split clients had to branch on.

### A-14 · Response contract doc

Added a header comment to \`src/lib/server/api-utils.ts\` codifying what's already true in the codebase:

- API routes: \`jsonResponse(data)\` for success, \`errorResponse(message, status, details?)\` for errors (always \`{ error: { code, message, details? } }\`)
- Form actions: \`throw redirect(303, path)\` for success (no body), \`fail(status, { message })\` for errors

Documentation only — existing code already follows this.

### A-15 · DELETE status code alignment

Eight detail-route DELETEs returned \`204 No Content\` on success while their error paths returned \`500 { error: {...} }\`. Clients had to branch on the success code. Flipped all eight to \`200 { success: true }\` so every DELETE response parses as JSON.

- \`/api/posts/[id]\`, \`/api/projects/[id]\`, \`/api/tags/[id]\`, \`/api/photos/[id]\`, \`/api/albums/[id]\`, \`/api/media/[id]\`, \`/api/admin/garden/[id]\`, \`/api/albums/[id]/photos\`

Unchanged: \`/api/heart/[...path]\` (CORS proxy — 204 is correct there), \`media/bulk-upload\` and \`media/[id]/metadata\` (not DELETE).

### Drive-by A-1 follow-up

\`src/lib/server/admin/authenticated-fetch.ts\` had \`detail = String(json.error)\` which produced \`"[object Object]"\` for the structured error shape introduced in #76. Now properly extracts \`.error.message\`, falling back to string-\`error\` for backward compatibility with any external shape.

## Test plan

- [ ] \`pnpm check\` — baseline 116 errors / 9 warnings, no new ones
- [ ] Admin UI: delete a post → toast/success renders normally (no regression from 204 change)
- [ ] \`curl -X DELETE -b session=... /api/posts/\<id\>\` → body is \`{"success":true}\`, status 200
- [ ] Trigger an admin fetch error (e.g. delete nonexistent id) → error message surfaces in the admin UI (not "[object Object]")