### PR TITLE
load photos filmstrip once at the section layout

### DIFF
--- a/src/routes/photos/+layout.server.ts
+++ b/src/routes/photos/+layout.server.ts
@@ -1,0 +1,17 @@
+import type { LayoutServerLoad } from './$types'
+import { getPaginatedPhotos } from '$lib/server/queries/photos'
+import { logger } from '$lib/server/logger'
+
+const FILMSTRIP_LIMIT = 100
+
+export const load: LayoutServerLoad = async ({ setHeaders }) => {
+	setHeaders({ 'cache-control': 'public, max-age=1800, stale-while-revalidate=86400' })
+
+	try {
+		const { photos, total } = await getPaginatedPhotos({ limit: FILMSTRIP_LIMIT, offset: 0 })
+		return { photoItems: photos, photoItemsTotal: total }
+	} catch (error) {
+		logger.error('Failed to load photos', error as Error)
+		return { photoItems: [], photoItemsTotal: 0, error: 'Failed to load photos' }
+	}
+}

--- a/src/routes/photos/+page.server.ts
+++ b/src/routes/photos/+page.server.ts
@@ -1,25 +1,12 @@
 import type { PageServerLoad } from './$types'
-import { getPaginatedPhotos } from '$lib/server/queries/photos'
 import { getOffsetPaginationMeta } from '$lib/server/api-utils'
-import { logger } from '$lib/server/logger'
 
 const PAGE_SIZE = 20
 
-export const load: PageServerLoad = async ({ setHeaders }) => {
-	setHeaders({ 'cache-control': 'public, max-age=1800, stale-while-revalidate=86400' })
-
-	try {
-		const { photos, total } = await getPaginatedPhotos({ limit: PAGE_SIZE, offset: 0 })
-		return {
-			photos,
-			pagination: getOffsetPaginationMeta(total, PAGE_SIZE, 0)
-		}
-	} catch (error) {
-		logger.error('Failed to load photos page', error as Error)
-		return {
-			photos: [],
-			pagination: null,
-			error: 'Failed to load photos'
-		}
+export const load: PageServerLoad = async ({ parent }) => {
+	const { photoItems, photoItemsTotal } = await parent()
+	return {
+		photos: photoItems.slice(0, PAGE_SIZE),
+		pagination: getOffsetPaginationMeta(photoItemsTotal, PAGE_SIZE, 0)
 	}
 }

--- a/src/routes/photos/[id]/+page.ts
+++ b/src/routes/photos/[id]/+page.ts
@@ -1,14 +1,14 @@
-import type { PhotoItem } from '$lib/types/photos'
 import type { PageLoad } from './$types'
 
-export const load: PageLoad = async ({ params, fetch }) => {
+export const load: PageLoad = async ({ params, fetch, parent }) => {
+	const { photoItems } = await parent()
+
 	try {
 		const mediaId = parseInt(params.id)
 		if (isNaN(mediaId)) {
 			throw new Error('Invalid media ID')
 		}
 
-		// Fetch the photo by media ID
 		const photoResponse = await fetch(`/api/photos/${mediaId}`)
 		if (!photoResponse.ok) {
 			if (photoResponse.status === 404) {
@@ -19,24 +19,16 @@ export const load: PageLoad = async ({ params, fetch }) => {
 
 		const photo = await photoResponse.json()
 
-		// Fetch all photos for the filmstrip navigation
-		const allPhotosResponse = await fetch('/api/photos?limit=100')
-		let photoItems: PhotoItem[] = []
-		if (allPhotosResponse.ok) {
-			const data = await allPhotosResponse.json()
-			photoItems = data.photoItems || []
-		}
-
 		return {
 			photo,
 			photoItems,
-			currentPhotoId: `media-${mediaId}` // Updated to use media prefix
+			currentPhotoId: `media-${mediaId}`
 		}
 	} catch (error) {
 		console.error('Error loading photo:', error)
 		return {
 			photo: null,
-			photoItems: [],
+			photoItems,
 			error: error instanceof Error ? error.message : 'Failed to load photo'
 		}
 	}


### PR DESCRIPTION
## Summary

Architecture audit A-12 — dedupe the filmstrip fetch across the photos section.

Previously, every visit to `/photos/[id]` re-fetched `/api/photos?limit=100` for the filmstrip navigation, even when clicking through from another photo in the same section. Grid (`/photos`) did its own separate 20-item DB query alongside.

Now:
- New `src/routes/photos/+layout.server.ts` loads up to 100 photos once for the section and sets cache-control
- `/photos/[id]` reads `photoItems` from `await parent()` — no more per-navigation filmstrip fetch
- `/photos` grid slices its first page from parent instead of issuing a duplicate query (and dropping its own header-set to avoid conflict with the layout)

## Impact

- Grid entry: 1 DB query (unchanged)
- Detail entry (deep link): 1 DB + 1 API fetch (was 2 API fetches)
- Detail → detail navigation: 0 filmstrip refetches (was 1 per navigation) — the main win

## Test plan

- [ ] `pnpm check` — baseline 116 errors / 9 warnings, no new ones
- [ ] Visit `/photos` → grid renders first 20 photos with correct pagination/hasMore
- [ ] Click a photo → detail view loads; filmstrip shows all photos
- [ ] Navigate photo → photo via filmstrip → no `/api/photos?limit=100` request in network tab
- [ ] Deep-link directly to `/photos/[id]` → filmstrip populates from layout load
- [ ] Infinite scroll / "load more" on the grid still works