### PR TITLE
fix missing og:image on edra link cards

### DIFF
--- a/src/lib/components/edra/headless/components/UrlEmbedExtended.svelte
+++ b/src/lib/components/edra/headless/components/UrlEmbedExtended.svelte
@@ -1,24 +1,31 @@
 <script lang="ts">
 	import type { NodeViewProps } from '@tiptap/core'
 	import { NodeViewWrapper } from 'svelte-tiptap'
-	import { onMount } from 'svelte'
 	import MoreHorizontal from '@lucide/svelte/icons/more-horizontal'
 	import EmbedContextMenu from './EmbedContextMenu.svelte'
 
 	const { editor, node, deleteNode, getPos, selected }: NodeViewProps = $props()
 
+	type FetchStatus = 'idle' | 'loading' | 'error'
+
 	let showActions = $state(false)
 	let showContextMenu = $state(false)
 	let contextMenuPosition = $state({ x: 0, y: 0 })
+	let status = $state<FetchStatus>('idle')
+	let lastFetchedUrl: string | null = null
+	let fetchGeneration = 0
 
 	// Check if this is a YouTube URL
 	const isYouTube = $derived(/(?:youtube\.com|youtu\.be)/.test(node.attrs.url || ''))
 
-	// Auto-fetch metadata when node has URL but no title (freshly converted from link)
-	onMount(() => {
-		if (node.attrs.url && !node.attrs.title && !isYouTube) {
-			refreshMetadata()
-		}
+	// Auto-fetch metadata when node has URL but is missing title/image. Re-runs if url changes.
+	$effect(() => {
+		const url = node.attrs.url
+		if (!url || isYouTube) return
+		if (node.attrs.title && node.attrs.image) return
+		if (url === lastFetchedUrl) return
+		lastFetchedUrl = url
+		refreshMetadata()
 	})
 
 	// Extract video ID from YouTube URL
@@ -54,11 +61,14 @@
 	}
 
 	async function refreshMetadata() {
-		if (!node.attrs.url) return
+		const requestUrl = node.attrs.url
+		if (!requestUrl) return
 
+		const generation = ++fetchGeneration
+		status = 'loading'
 		try {
 			const response = await fetch(
-				`/api/og-metadata?url=${encodeURIComponent(node.attrs.url)}&refresh=true`
+				`/api/og-metadata?url=${encodeURIComponent(requestUrl)}&refresh=true`
 			)
 			if (!response.ok) {
 				throw new Error('Failed to fetch metadata')
@@ -66,7 +76,9 @@
 
 			const metadata = await response.json()
 
-			// Update the node attributes
+			// Ignore the response if the node's url changed or a newer fetch was started.
+			if (generation !== fetchGeneration || node.attrs.url !== requestUrl) return
+
 			const pos = getPos()
 			if (typeof pos === 'number') {
 				editor
@@ -81,9 +93,18 @@
 					})
 					.run()
 			}
+			status = 'idle'
 		} catch (err) {
+			if (generation !== fetchGeneration) return
 			console.error('Error refreshing metadata:', err)
+			status = 'error'
 		}
+	}
+
+	function retryFetch(event: MouseEvent) {
+		event.stopPropagation()
+		lastFetchedUrl = null
+		refreshMetadata()
 	}
 
 	function openLink() {
@@ -243,6 +264,8 @@
 					<div class="edra-url-embed-image">
 						<img src={node.attrs.image} alt={node.attrs.title || 'Link preview'} />
 					</div>
+				{:else if status === 'loading'}
+					<div class="edra-url-embed-image edra-url-embed-image-skeleton" aria-hidden="true"></div>
 				{/if}
 				<div class="edra-url-embed-text">
 					<div class="edra-url-embed-meta">
@@ -254,6 +277,19 @@
 								? decodeHtmlEntities(node.attrs.siteName)
 								: getDomain(node.attrs.url)}</span
 						>
+						{#if status === 'loading' && !node.attrs.title}
+							<span class="edra-url-embed-status">Fetching preview…</span>
+						{:else if status === 'error' && !node.attrs.title}
+							<span
+								class="edra-url-embed-retry"
+								role="button"
+								tabindex="0"
+								onclick={retryFetch}
+								onkeydown={(e) => {
+									if (e.key === 'Enter' || e.key === ' ') retryFetch(e as unknown as MouseEvent)
+								}}>Couldn't load preview — Retry</span
+							>
+						{/if}
 					</div>
 					{#if node.attrs.title}
 						<h3 class="edra-url-embed-title">{decodeHtmlEntities(node.attrs.title)}</h3>
@@ -393,6 +429,36 @@
 			width: 100%;
 			height: 100%;
 			object-fit: cover;
+		}
+	}
+
+	.edra-url-embed-image-skeleton {
+		background: linear-gradient(90deg, $gray-85 0%, $gray-90 50%, $gray-85 100%);
+		background-size: 200% 100%;
+		animation: edra-url-embed-shimmer 1.2s ease-in-out infinite;
+	}
+
+	@keyframes edra-url-embed-shimmer {
+		0% {
+			background-position: 200% 0;
+		}
+		100% {
+			background-position: -200% 0;
+		}
+	}
+
+	.edra-url-embed-status {
+		font-style: italic;
+		color: $gray-50;
+	}
+
+	.edra-url-embed-retry {
+		color: $primary-color;
+		cursor: pointer;
+		text-decoration: underline;
+
+		&:hover {
+			text-decoration: none;
 		}
 	}
 

--- a/src/lib/server/enrich-url-embeds.ts
+++ b/src/lib/server/enrich-url-embeds.ts
@@ -1,0 +1,76 @@
+import { scrapeOgMetadata, type OgMetadata } from './og-metadata'
+
+interface UrlEmbedAttrs {
+	url?: string
+	title?: string
+	description?: string
+	image?: string
+	favicon?: string
+	siteName?: string
+	[key: string]: unknown
+}
+
+interface RichTextNode {
+	type?: string
+	attrs?: UrlEmbedAttrs
+	content?: RichTextNode[]
+	[key: string]: unknown
+}
+
+export async function enrichUrlEmbeds(content: unknown): Promise<void> {
+	if (!content || typeof content !== 'object') return
+
+	const nodes: RichTextNode[] = []
+	collectMissing(content as RichTextNode, nodes)
+	if (nodes.length === 0) return
+
+	const unique = new Map<string, RichTextNode[]>()
+	for (const node of nodes) {
+		const url = node.attrs?.url
+		if (!url) continue
+		const bucket = unique.get(url) ?? []
+		bucket.push(node)
+		unique.set(url, bucket)
+	}
+
+	await Promise.all(
+		[...unique.entries()].map(async ([url, targets]) => {
+			try {
+				const metadata = await scrapeOgMetadata(url)
+				for (const node of targets) {
+					applyMetadata(node, metadata)
+				}
+			} catch (err) {
+				console.error(`Failed to enrich urlEmbed for ${url}:`, err)
+			}
+		})
+	)
+}
+
+function collectMissing(node: RichTextNode, out: RichTextNode[]): void {
+	if (!node) return
+
+	if (node.type === 'urlEmbed' && node.attrs?.url && needsEnrichment(node.attrs)) {
+		out.push(node)
+	}
+
+	if (Array.isArray(node.content)) {
+		for (const child of node.content) {
+			collectMissing(child, out)
+		}
+	}
+}
+
+function needsEnrichment(attrs: UrlEmbedAttrs): boolean {
+	return !attrs.image || !attrs.title
+}
+
+function applyMetadata(node: RichTextNode, metadata: OgMetadata): void {
+	const attrs: UrlEmbedAttrs = { ...(node.attrs ?? {}) }
+	if (!attrs.title && metadata.title) attrs.title = metadata.title
+	if (!attrs.description && metadata.description) attrs.description = metadata.description
+	if (!attrs.image && metadata.image) attrs.image = metadata.image
+	if (!attrs.favicon && metadata.favicon) attrs.favicon = metadata.favicon
+	if (!attrs.siteName && metadata.siteName) attrs.siteName = metadata.siteName
+	node.attrs = attrs
+}

--- a/src/lib/server/og-metadata.ts
+++ b/src/lib/server/og-metadata.ts
@@ -1,0 +1,187 @@
+import redis from '../../routes/api/redis-client'
+import { safeKey } from './cache-keys'
+
+export interface OgMetadata {
+	url: string
+	title: string | null
+	description: string | null
+	image: string | null
+	siteName: string | null
+	favicon: string | null
+}
+
+interface ScrapeOptions {
+	forceRefresh?: boolean
+}
+
+const TTL_WITH_IMAGE = 86400
+const TTL_WITHOUT_IMAGE = 300
+const FETCH_TIMEOUT_MS = 8000
+const BROWSER_UA =
+	'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36'
+
+export async function scrapeOgMetadata(
+	targetUrl: string,
+	{ forceRefresh = false }: ScrapeOptions = {}
+): Promise<OgMetadata> {
+	const cacheKey = `og-metadata:${safeKey(targetUrl)}`
+
+	if (!forceRefresh) {
+		const cached = await redis.get(cacheKey)
+		if (cached) {
+			return JSON.parse(cached) as OgMetadata
+		}
+	}
+
+	const youtube = youtubeMetadata(targetUrl)
+	if (youtube) {
+		await cacheMetadata(cacheKey, youtube)
+		return youtube
+	}
+
+	const response = await fetch(targetUrl, {
+		headers: { 'User-Agent': BROWSER_UA },
+		signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+		redirect: 'follow'
+	})
+
+	if (!response.ok) {
+		throw new Error(`Failed to fetch URL: ${response.status}`)
+	}
+
+	const html = await response.text()
+	const rawImage =
+		extractMetaContent(html, 'og:image') ||
+		extractMetaContent(html, 'og:image:url') ||
+		extractMetaContent(html, 'og:image:secure_url') ||
+		extractMetaContent(html, 'twitter:image') ||
+		extractMetaContent(html, 'twitter:image:src') ||
+		extractLinkHref(html, 'image_src')
+
+	const metadata: OgMetadata = {
+		url: targetUrl,
+		title:
+			extractMetaContent(html, 'og:title') ||
+			extractMetaContent(html, 'twitter:title') ||
+			extractTitle(html),
+		description:
+			extractMetaContent(html, 'og:description') ||
+			extractMetaContent(html, 'twitter:description') ||
+			extractMetaContent(html, 'description'),
+		image: resolveAbsoluteUrl(rawImage, targetUrl),
+		siteName: extractMetaContent(html, 'og:site_name'),
+		favicon: extractFavicon(targetUrl, html)
+	}
+
+	await cacheMetadata(cacheKey, metadata)
+	return metadata
+}
+
+async function cacheMetadata(cacheKey: string, metadata: OgMetadata): Promise<void> {
+	const ttl = metadata.image ? TTL_WITH_IMAGE : TTL_WITHOUT_IMAGE
+	await redis.set(cacheKey, JSON.stringify(metadata), 'EX', ttl)
+}
+
+function youtubeMetadata(targetUrl: string): OgMetadata | null {
+	if (!/(?:youtube\.com|youtu\.be)/.test(targetUrl)) return null
+
+	const patterns = [
+		/(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&\n?#]+)/,
+		/youtube\.com\/watch\?.*v=([^&\n?#]+)/
+	]
+
+	for (const pattern of patterns) {
+		const match = targetUrl.match(pattern)
+		if (match && match[1]) {
+			return {
+				url: targetUrl,
+				title: 'YouTube Video',
+				description: 'Watch this video on YouTube',
+				image: `https://img.youtube.com/vi/${match[1]}/maxresdefault.jpg`,
+				favicon: 'https://www.youtube.com/favicon.ico',
+				siteName: 'YouTube'
+			}
+		}
+	}
+
+	return null
+}
+
+function extractMetaContent(html: string, property: string): string | null {
+	const escaped = property.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+	const propertyMatch = html.match(
+		new RegExp(`<meta[^>]*property=["']${escaped}["'][^>]*content=["']([^"']*)["']`, 'i')
+	)
+	if (propertyMatch && propertyMatch[1]) return decodeEntities(propertyMatch[1])
+
+	const nameMatch = html.match(
+		new RegExp(`<meta[^>]*name=["']${escaped}["'][^>]*content=["']([^"']*)["']`, 'i')
+	)
+	if (nameMatch && nameMatch[1]) return decodeEntities(nameMatch[1])
+
+	const contentFirstMatch = html.match(
+		new RegExp(`<meta[^>]*content=["']([^"']*)["'][^>]*(?:property|name)=["']${escaped}["']`, 'i')
+	)
+	if (contentFirstMatch && contentFirstMatch[1]) return decodeEntities(contentFirstMatch[1])
+
+	return null
+}
+
+function extractLinkHref(html: string, rel: string): string | null {
+	const escaped = rel.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+	const match =
+		html.match(new RegExp(`<link[^>]*rel=["']${escaped}["'][^>]*href=["']([^"']+)["']`, 'i')) ||
+		html.match(new RegExp(`<link[^>]*href=["']([^"']+)["'][^>]*rel=["']${escaped}["']`, 'i'))
+	return match ? match[1] : null
+}
+
+function extractTitle(html: string): string | null {
+	const match = html.match(/<title[^>]*>([^<]+)<\/title>/i)
+	return match ? decodeEntities(match[1].trim()) : null
+}
+
+function extractFavicon(baseUrl: string, html: string): string | null {
+	if (baseUrl.includes('github.com')) {
+		return 'https://github.githubassets.com/favicons/favicon.svg'
+	}
+
+	const patterns = [
+		/<link[^>]*rel=["'](?:shortcut )?icon["'][^>]*href=["']([^"']+)["']/i,
+		/<link[^>]*href=["']([^"']+)["'][^>]*rel=["'](?:shortcut )?icon["']/i,
+		/<link[^>]*rel=["']apple-touch-icon["'][^>]*href=["']([^"']+)["']/i
+	]
+
+	for (const pattern of patterns) {
+		const match = html.match(pattern)
+		if (match) {
+			return resolveAbsoluteUrl(match[1], baseUrl)
+		}
+	}
+
+	try {
+		const url = new URL(baseUrl)
+		return `${url.protocol}//${url.host}/favicon.ico`
+	} catch {
+		return null
+	}
+}
+
+function resolveAbsoluteUrl(raw: string | null, baseUrl: string): string | null {
+	if (!raw) return null
+	try {
+		return new URL(raw, baseUrl).href
+	} catch {
+		return null
+	}
+}
+
+function decodeEntities(text: string): string {
+	return text
+		.replace(/&amp;/g, '&')
+		.replace(/&lt;/g, '<')
+		.replace(/&gt;/g, '>')
+		.replace(/&quot;/g, '"')
+		.replace(/&#39;/g, "'")
+		.replace(/&#x27;/g, "'")
+		.replace(/&#x2F;/g, '/')
+}

--- a/src/routes/api/og-metadata/+server.ts
+++ b/src/routes/api/og-metadata/+server.ts
@@ -1,7 +1,6 @@
 import { json } from '@sveltejs/kit'
 import type { RequestHandler } from './$types'
-import redis from '../redis-client'
-import { safeKey } from '$lib/server/cache-keys'
+import { scrapeOgMetadata } from '$lib/server/og-metadata'
 
 export const GET: RequestHandler = async ({ url }) => {
 	const targetUrl = url.searchParams.get('url')
@@ -12,167 +11,14 @@ export const GET: RequestHandler = async ({ url }) => {
 	}
 
 	try {
-		// Check cache first (unless force refresh is requested)
-		const cacheKey = `og-metadata:${safeKey(targetUrl)}`
-
-		if (!forceRefresh) {
-			const cached = await redis.get(cacheKey)
-
-			if (cached) {
-				console.log(`Cache hit for ${targetUrl}`)
-				return json(JSON.parse(cached))
-			}
-		} else {
-			console.log(`Force refresh requested for ${targetUrl}`)
-		}
-
-		// For YouTube URLs, we can construct metadata without fetching
-		const isYouTube = /(?:youtube\.com|youtu\.be)/.test(targetUrl)
-		if (isYouTube) {
-			// Extract video ID
-			const patterns = [
-				/(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&\n?#]+)/,
-				/youtube\.com\/watch\?.*v=([^&\n?#]+)/
-			]
-
-			let videoId = null
-			for (const pattern of patterns) {
-				const match = targetUrl.match(pattern)
-				if (match && match[1]) {
-					videoId = match[1]
-					break
-				}
-			}
-
-			if (videoId) {
-				// Return YouTube-specific metadata
-				const ogData = {
-					url: targetUrl,
-					title: 'YouTube Video',
-					description: 'Watch this video on YouTube',
-					image: `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`,
-					favicon: 'https://www.youtube.com/favicon.ico',
-					siteName: 'YouTube'
-				}
-
-				// Cache for 24 hours (86400 seconds)
-				await redis.set(cacheKey, JSON.stringify(ogData), 'EX', 86400)
-				console.log(`Cached YouTube metadata for ${targetUrl}`)
-
-				return json(ogData)
-			}
-		}
-
-		// Fetch the HTML content
-		const response = await fetch(targetUrl, {
-			headers: {
-				'User-Agent': 'Mozilla/5.0 (compatible; OpenGraphBot/1.0)'
-			}
-		})
-
-		if (!response.ok) {
-			throw new Error(`Failed to fetch URL: ${response.status}`)
-		}
-
-		const html = await response.text()
-
-		// Parse OpenGraph tags
-		const ogData = {
-			url: targetUrl,
-			title: extractMetaContent(html, 'og:title') || extractTitle(html),
-			description:
-				extractMetaContent(html, 'og:description') || extractMetaContent(html, 'description'),
-			image: extractMetaContent(html, 'og:image'),
-			siteName: extractMetaContent(html, 'og:site_name'),
-			favicon: extractFavicon(targetUrl, html)
-		}
-
-		// Cache for 24 hours (86400 seconds)
-		await redis.set(cacheKey, JSON.stringify(ogData), 'EX', 86400)
-		console.log(`Cached metadata for ${targetUrl}`)
-
-		return json(ogData)
+		const metadata = await scrapeOgMetadata(targetUrl, { forceRefresh })
+		return json(metadata)
 	} catch (error) {
 		console.error('Error fetching OpenGraph data:', error)
-		return json(
-			{
-				error: 'Failed to fetch metadata',
-				url: targetUrl
-			},
-			{ status: 500 }
-		)
+		return json({ error: 'Failed to fetch metadata', url: targetUrl }, { status: 500 })
 	}
 }
 
-function extractMetaContent(html: string, property: string): string | null {
-	// Try property attribute first (for og: tags)
-	const propertyMatch = html.match(
-		new RegExp(`<meta[^>]*property=["']${property}["'][^>]*content=["']([^"']+)["']`, 'i')
-	)
-	if (propertyMatch) return propertyMatch[1]
-
-	// Try name attribute (for description)
-	const nameMatch = html.match(
-		new RegExp(`<meta[^>]*name=["']${property}["'][^>]*content=["']([^"']+)["']`, 'i')
-	)
-	if (nameMatch) return nameMatch[1]
-
-	// Try content first pattern
-	const contentFirstMatch = html.match(
-		new RegExp(`<meta[^>]*content=["']([^"']+)["'][^>]*(?:property|name)=["']${property}["']`, 'i')
-	)
-	if (contentFirstMatch) return contentFirstMatch[1]
-
-	return null
-}
-
-function extractTitle(html: string): string | null {
-	const match = html.match(/<title[^>]*>([^<]+)<\/title>/i)
-	return match ? match[1].trim() : null
-}
-
-function extractFavicon(baseUrl: string, html: string): string | null {
-	// Special case for GitHub
-	if (baseUrl.includes('github.com')) {
-		return 'https://github.githubassets.com/favicons/favicon.svg'
-	}
-
-	// Try various favicon patterns
-	const patterns = [
-		/<link[^>]*rel=["'](?:shortcut )?icon["'][^>]*href=["']([^"']+)["']/i,
-		/<link[^>]*href=["']([^"']+)["'][^>]*rel=["'](?:shortcut )?icon["']/i,
-		/<link[^>]*rel=["']apple-touch-icon["'][^>]*href=["']([^"']+)["']/i
-	]
-
-	for (const pattern of patterns) {
-		const match = html.match(pattern)
-		if (match) {
-			const favicon = match[1]
-			// Convert relative URLs to absolute
-			if (favicon.startsWith('http')) {
-				return favicon
-			} else if (favicon.startsWith('//')) {
-				return 'https:' + favicon
-			} else if (favicon.startsWith('/')) {
-				const url = new URL(baseUrl)
-				return `${url.protocol}//${url.host}${favicon}`
-			} else {
-				const url = new URL(baseUrl)
-				return `${url.protocol}//${url.host}/${favicon}`
-			}
-		}
-	}
-
-	// Default favicon path
-	try {
-		const url = new URL(baseUrl)
-		return `${url.protocol}//${url.host}/favicon.ico`
-	} catch {
-		return null
-	}
-}
-
-// Add POST handler for Editor.js link tool
 export const POST: RequestHandler = async ({ request }) => {
 	const { url: targetUrl } = await request.json()
 
@@ -181,124 +27,20 @@ export const POST: RequestHandler = async ({ request }) => {
 	}
 
 	try {
-		// Check cache first - using same cache key format
-		const cacheKey = `og-metadata:${safeKey(targetUrl)}`
-		const cached = await redis.get(cacheKey)
-
-		if (cached) {
-			console.log(`Cache hit for ${targetUrl} (POST)`)
-			const ogData = JSON.parse(cached)
-			return json({
-				success: 1,
-				link: targetUrl,
-				meta: {
-					title: ogData.title || '',
-					description: ogData.description || '',
-					image: {
-						url: ogData.image || ''
-					}
-				}
-			})
-		}
-
-		// For YouTube URLs, we can construct metadata without fetching
-		const isYouTube = /(?:youtube\.com|youtu\.be)/.test(targetUrl)
-		if (isYouTube) {
-			// Extract video ID
-			const patterns = [
-				/(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&\n?#]+)/,
-				/youtube\.com\/watch\?.*v=([^&\n?#]+)/
-			]
-
-			let videoId = null
-			for (const pattern of patterns) {
-				const match = targetUrl.match(pattern)
-				if (match && match[1]) {
-					videoId = match[1]
-					break
-				}
-			}
-
-			if (videoId) {
-				// Return YouTube-specific metadata
-				const ogData = {
-					url: targetUrl,
-					title: 'YouTube Video',
-					description: 'Watch this video on YouTube',
-					image: `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`,
-					siteName: 'YouTube',
-					favicon: 'https://www.youtube.com/favicon.ico'
-				}
-
-				// Cache for 24 hours (86400 seconds)
-				await redis.set(cacheKey, JSON.stringify(ogData), 'EX', 86400)
-				console.log(`Cached YouTube metadata for ${targetUrl} (POST)`)
-
-				return json({
-					success: 1,
-					link: targetUrl,
-					meta: {
-						title: ogData.title || '',
-						description: ogData.description || '',
-						image: {
-							url: ogData.image || ''
-						}
-					}
-				})
-			}
-		}
-
-		// Fetch the HTML content
-		const response = await fetch(targetUrl, {
-			headers: {
-				'User-Agent': 'Mozilla/5.0 (compatible; OpenGraphBot/1.0)'
-			}
-		})
-
-		if (!response.ok) {
-			throw new Error(`Failed to fetch URL: ${response.status}`)
-		}
-
-		const html = await response.text()
-
-		// Parse OpenGraph tags
-		const title = extractMetaContent(html, 'og:title') || extractTitle(html)
-		const description =
-			extractMetaContent(html, 'og:description') || extractMetaContent(html, 'description')
-		const image = extractMetaContent(html, 'og:image')
-		const siteName = extractMetaContent(html, 'og:site_name')
-		const favicon = extractFavicon(targetUrl, html)
-
-		// Cache the data in the same format as GET
-		const ogData = {
-			url: targetUrl,
-			title,
-			description,
-			image,
-			siteName,
-			favicon
-		}
-		await redis.set(cacheKey, JSON.stringify(ogData), 'EX', 86400)
-		console.log(`Cached metadata for ${targetUrl} (POST)`)
-
+		const metadata = await scrapeOgMetadata(targetUrl)
 		return json({
 			success: 1,
 			link: targetUrl,
 			meta: {
-				title: title || '',
-				description: description || '',
+				title: metadata.title || '',
+				description: metadata.description || '',
 				image: {
-					url: image || ''
+					url: metadata.image || ''
 				}
 			}
 		})
 	} catch (error) {
 		console.error('Error fetching OpenGraph data:', error)
-		return json(
-			{
-				success: 0
-			},
-			{ status: 500 }
-		)
+		return json({ success: 0 }, { status: 500 })
 	}
 }

--- a/src/routes/api/posts/+server.ts
+++ b/src/routes/api/posts/+server.ts
@@ -15,6 +15,7 @@ import {
 	extractMediaIds,
 	type MediaUsageReference
 } from '$lib/server/media-usage.js'
+import { enrichUrlEmbeds } from '$lib/server/enrich-url-embeds'
 
 export const GET: RequestHandler = async (event) => {
 	if (!checkAdminAuth(event)) {
@@ -121,6 +122,8 @@ export const POST: RequestHandler = async (event) => {
 		if (data.attachedPhotos && data.attachedPhotos.length > 0 && !featuredImageId) {
 			featuredImageId = data.attachedPhotos[0]
 		}
+
+		await enrichUrlEmbeds(data.content)
 
 		const post = await prisma.$transaction(async (tx) => {
 			const created = await tx.post.create({

--- a/src/routes/api/posts/[id]/+server.ts
+++ b/src/routes/api/posts/[id]/+server.ts
@@ -10,6 +10,7 @@ import {
 	trackMediaUsage,
 	type MediaUsageReference
 } from '$lib/server/media-usage.js'
+import { enrichUrlEmbeds } from '$lib/server/enrich-url-embeds'
 
 export const GET: RequestHandler = async (event) => {
 	if (!checkAdminAuth(event)) {
@@ -99,6 +100,8 @@ export const PUT: RequestHandler = async (event) => {
 				}
 			}
 		}
+
+		await enrichUrlEmbeds(data.content)
 
 		const post = await prisma.$transaction(async (tx) => {
 			const updated = await tx.post.update({
@@ -210,7 +213,10 @@ export const PATCH: RequestHandler = async (event) => {
 		if (data.title !== undefined) updateData.title = data.title
 		if (data.slug !== undefined) updateData.slug = data.slug
 		if (data.type !== undefined) updateData.postType = data.type
-		if (data.content !== undefined) updateData.content = data.content
+		if (data.content !== undefined) {
+			await enrichUrlEmbeds(data.content)
+			updateData.content = data.content
+		}
 		if (data.featuredImage !== undefined) updateData.featuredImage = data.featuredImage
 		if (data.attachedPhotos !== undefined)
 			updateData.attachments =


### PR DESCRIPTION
## Summary
- harden `/api/og-metadata` scraping: twitter:image / image_src fallbacks, relative→absolute image url resolution, realistic browser UA, 8s fetch timeout, and a short 5-min TTL when image is missing so transient failures self-heal instead of sticking for 24h
- enrich urlEmbed nodes at post save time so the saved content is the source of truth — immunizes against the editor race where the user hits save before the async metadata fetch completes
- editor UX: swap onMount for an `$effect` that re-runs on url change, add loading skeleton + retry affordance, and guard against stale writes with a generation counter

## Why
a universe post with a valid `og:image` was rendering a blank link card. manually running extraction against the target html succeeds, so the scraper isn't the issue — the node was persisted with empty attrs, either because the user saved before the client fetch completed or because a transient failure got cached for 24h. the public page never re-fetches.

## Test plan
- [ ] `GET /api/og-metadata?url=https://collectivefutures.blog/design-was-never-the-bottleneck/&refresh=true` returns the ghost-hosted og:image in `image`
- [ ] fetch a 404 url, confirm null-image response cached for 5 min not 24h (`redis-cli TTL og-metadata:...`)
- [ ] paste a url in the editor and save within ~200ms — the saved post still has `image` populated (write-path enrichment filled it server-side)
- [ ] pick a url that serves twitter:image but not og:image (e.g. many x.com links) — image populates
- [ ] construct a page with `<meta property="og:image" content="/img.png">` — absolute url comes back
- [ ] throttle `/api/og-metadata` or point at a hanging url — skeleton + error state + retry button render and recover
- [ ] edit a url in an existing embed — old metadata is replaced and a late response from the previous url can't clobber the new one

## Backfill
existing posts with blank link cards will re-populate by opening the post in the admin editor and re-saving (the write path will enrich). no migration needed.