### PR TITLE
self-host og:image thumbnails for link cards

### DIFF
--- a/prisma/migrations/20260422000000_add_media_link_card_flag/migration.sql
+++ b/prisma/migrations/20260422000000_add_media_link_card_flag/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Media" ADD COLUMN "isLinkCardImage" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateIndex
+CREATE INDEX "Media_isLinkCardImage_idx" ON "Media"("isLinkCardImage");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -127,6 +127,7 @@ model Media {
   originalName     String?      @db.VarChar(255)
   updatedAt        DateTime     @updatedAt
   isPhotography    Boolean      @default(false)
+  isLinkCardImage  Boolean      @default(false)
   exifData         Json?
   photoCaption     String?
   photoTitle       String?      @db.VarChar(255)
@@ -145,6 +146,7 @@ model Media {
   photos           Photo[]
 
   @@index([isPhotography])
+  @@index([isLinkCardImage])
 }
 
 model MediaUsage {

--- a/src/lib/components/edra/extensions/url-embed/UrlEmbed.ts
+++ b/src/lib/components/edra/extensions/url-embed/UrlEmbed.ts
@@ -59,6 +59,9 @@ export const UrlEmbed = Node.create<UrlEmbedOptions>({
 			image: {
 				default: null
 			},
+			imageMediaId: {
+				default: null
+			},
 			favicon: {
 				default: null
 			},

--- a/src/lib/server/enrich-url-embeds.ts
+++ b/src/lib/server/enrich-url-embeds.ts
@@ -1,10 +1,12 @@
 import { scrapeOgMetadata, type OgMetadata } from './og-metadata'
+import { downloadOgImage } from './og-image-download'
 
 interface UrlEmbedAttrs {
 	url?: string
 	title?: string
 	description?: string
 	image?: string
+	imageMediaId?: number
 	favicon?: string
 	siteName?: string
 	[key: string]: unknown
@@ -37,14 +39,22 @@ export async function enrichUrlEmbeds(content: unknown): Promise<void> {
 		[...unique.entries()].map(async ([url, targets]) => {
 			try {
 				const metadata = await scrapeOgMetadata(url)
+				const hosted =
+					metadata.image && !isLocallyHosted(metadata.image)
+						? await downloadOgImage(metadata.image, url)
+						: null
 				for (const node of targets) {
-					applyMetadata(node, metadata)
+					applyMetadata(node, metadata, hosted)
 				}
 			} catch (err) {
 				console.error(`Failed to enrich urlEmbed for ${url}:`, err)
 			}
 		})
 	)
+}
+
+function isLocallyHosted(imageUrl: string): boolean {
+	return imageUrl.startsWith('/local-uploads/') || imageUrl.startsWith('/api/media/')
 }
 
 function collectMissing(node: RichTextNode, out: RichTextNode[]): void {
@@ -62,14 +72,29 @@ function collectMissing(node: RichTextNode, out: RichTextNode[]): void {
 }
 
 function needsEnrichment(attrs: UrlEmbedAttrs): boolean {
-	return !attrs.image || !attrs.title
+	if (!attrs.title) return true
+	if (!attrs.image) return true
+	// Legacy/hotlinked images should be re-hosted on our own storage.
+	if (!isLocallyHosted(attrs.image)) return true
+	return false
 }
 
-function applyMetadata(node: RichTextNode, metadata: OgMetadata): void {
+function applyMetadata(
+	node: RichTextNode,
+	metadata: OgMetadata,
+	hosted: { mediaId: number; url: string } | null
+): void {
 	const attrs: UrlEmbedAttrs = { ...(node.attrs ?? {}) }
 	if (!attrs.title && metadata.title) attrs.title = metadata.title
 	if (!attrs.description && metadata.description) attrs.description = metadata.description
-	if (!attrs.image && metadata.image) attrs.image = metadata.image
+
+	if (hosted) {
+		attrs.image = hosted.url
+		attrs.imageMediaId = hosted.mediaId
+	} else if (!attrs.image && metadata.image) {
+		attrs.image = metadata.image
+	}
+
 	if (!attrs.favicon && metadata.favicon) attrs.favicon = metadata.favicon
 	if (!attrs.siteName && metadata.siteName) attrs.siteName = metadata.siteName
 	node.attrs = attrs

--- a/src/lib/server/media-usage.ts
+++ b/src/lib/server/media-usage.ts
@@ -270,6 +270,11 @@ function extractMediaFromRichText(content: unknown): number[] {
 			}
 		}
 
+		// Handle urlEmbed link-card thumbnails that we downloaded into our media store
+		if (node.type === 'urlEmbed' && typeof node.attrs?.imageMediaId === 'number') {
+			mediaIds.push(node.attrs.imageMediaId as number)
+		}
+
 		// Recursively traverse child nodes
 		if (node.content) {
 			for (const child of node.content) {

--- a/src/lib/server/og-image-download.ts
+++ b/src/lib/server/og-image-download.ts
@@ -1,0 +1,125 @@
+import { prisma } from './database'
+import { uploadFile } from './cloudinary'
+import { logger } from './logger'
+
+const FETCH_TIMEOUT_MS = 10000
+const MAX_BYTES = 10 * 1024 * 1024
+const BROWSER_UA =
+	'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36'
+
+export interface DownloadedOgImage {
+	mediaId: number
+	url: string
+}
+
+/**
+ * Download an og:image and store it as a Media record. Returns the hosted public url,
+ * or null on any failure so callers can fall back to the original source url.
+ * `referer` is the page the image was found on — some hosts require it to serve bytes.
+ */
+export async function downloadOgImage(
+	sourceUrl: string,
+	referer?: string
+): Promise<DownloadedOgImage | null> {
+	try {
+		const response = await fetch(sourceUrl, {
+			headers: {
+				'User-Agent': BROWSER_UA,
+				Accept: 'image/avif,image/webp,image/apng,image/*,*/*;q=0.8',
+				...(referer ? { Referer: referer } : {})
+			},
+			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+			redirect: 'follow'
+		})
+
+		if (!response.ok) {
+			logger.info('og:image download skipped (non-2xx)', {
+				sourceUrl,
+				status: response.status
+			})
+			return null
+		}
+
+		const contentType = (response.headers.get('content-type') || '').split(';')[0].trim()
+		if (!contentType.startsWith('image/')) {
+			logger.info('og:image download skipped (non-image content-type)', {
+				sourceUrl,
+				contentType
+			})
+			return null
+		}
+
+		const buffer = Buffer.from(await response.arrayBuffer())
+		if (buffer.byteLength === 0 || buffer.byteLength > MAX_BYTES) {
+			logger.info('og:image download skipped (size out of bounds)', {
+				sourceUrl,
+				size: buffer.byteLength
+			})
+			return null
+		}
+
+		const filename = buildFilename(sourceUrl, contentType)
+		const file = new File([buffer], filename, { type: contentType })
+
+		const uploadResult = await uploadFile(file, 'media')
+		if (!uploadResult.success || !uploadResult.secureUrl) {
+			logger.error('og:image upload failed', new Error(uploadResult.error || 'unknown'))
+			return null
+		}
+
+		const media = await prisma.media.create({
+			data: {
+				filename: file.name,
+				originalName: sourceUrl.slice(0, 255),
+				mimeType: file.type,
+				size: buffer.byteLength,
+				url: uploadResult.secureUrl,
+				thumbnailUrl: uploadResult.thumbnailUrl,
+				width: uploadResult.width,
+				height: uploadResult.height,
+				dominantColor: uploadResult.dominantColor,
+				colors: uploadResult.colors,
+				aspectRatio: uploadResult.aspectRatio,
+				isPhotography: false,
+				isLinkCardImage: true
+			}
+		})
+
+		return { mediaId: media.id, url: media.url }
+	} catch (err) {
+		logger.error('og:image download errored', err as Error, { sourceUrl })
+		return null
+	}
+}
+
+function buildFilename(sourceUrl: string, contentType: string): string {
+	const ext = extFromContentType(contentType)
+	let base = 'og-image'
+	try {
+		const pathname = new URL(sourceUrl).pathname
+		const tail = pathname.split('/').filter(Boolean).pop()
+		if (tail) base = tail.replace(/\.[^.]+$/, '').slice(0, 80) || base
+	} catch {
+		// fall through
+	}
+	return `${base}.${ext}`
+}
+
+function extFromContentType(contentType: string): string {
+	switch (contentType) {
+		case 'image/jpeg':
+			return 'jpg'
+		case 'image/png':
+			return 'png'
+		case 'image/gif':
+			return 'gif'
+		case 'image/webp':
+			return 'webp'
+		case 'image/avif':
+			return 'avif'
+		case 'image/svg+xml':
+			return 'svg'
+		default:
+			return 'img'
+	}
+}

--- a/src/routes/api/media/+server.ts
+++ b/src/routes/api/media/+server.ts
@@ -29,8 +29,8 @@ export const GET: RequestHandler = async (event) => {
 		const sort = event.url.searchParams.get('sort') || 'newest'
 		const albumId = event.url.searchParams.get('albumId')
 
-		// Build where clause
-		const whereConditions: Prisma.MediaWhereInput[] = []
+		// Build where clause. Link-card thumbnails are internal assets and never shown in the library.
+		const whereConditions: Prisma.MediaWhereInput[] = [{ isLinkCardImage: false }]
 
 		// Handle mime type filtering
 		if (mimeType && mimeType !== 'all') {


### PR DESCRIPTION
## Summary
- download og:images at post save time and store them as `Media` rows (cloudinary in prod, local disk in dev), then point the `urlEmbed` node at the self-hosted url
- new `isLinkCardImage` flag on `Media` keeps these auto-downloaded thumbnails out of the media library
- extend rich-text media walker to pick up `urlEmbed.imageMediaId` so link-card assets show up in `media.usedIn` and don't look orphaned

## Why
after #81 the editor was saving `og:image` hotlink urls directly in the post json. hotlinking is fragile: hosts block based on referer, CSPs trip, images get removed or renamed, and we leak reader ip to third parties. self-hosting eliminates link rot and makes link cards behave like any other image asset in the app.

## Migration
adds `Media.isLinkCardImage` (boolean, default false) + index. run `npm run db:migrate` in dev, `npm run db:deploy` in prod.

## Existing posts
re-saving a post with a foreign image url will trigger the download and swap in the hosted url automatically — no backfill script needed. posts with cloudinary/local image urls already are treated as locally hosted and skipped.

## Test plan
- [ ] paste a url with a valid og:image and save — the saved `content` has a cloudinary / `/local-uploads/` url, not the origin url
- [ ] confirm the new `Media` row has `isLinkCardImage = true`
- [ ] `GET /api/media` does not return link-card rows
- [ ] source url with broken/403 og:image — save succeeds; attrs keep the original hotlink as fallback
- [ ] image > 10MB or non-image content-type — download is skipped, hotlink is kept
- [ ] open an existing post saved under #81 with a hotlink image, save it again, confirm the image attr becomes a hosted url
- [ ] deleting a post decrements `media.usedIn` via existing `MediaUsage` tracking for the link-card row