### PR TITLE
proxy + self-host og:image and favicon for link cards

### DIFF
--- a/src/lib/components/edra/extensions/url-embed/UrlEmbed.ts
+++ b/src/lib/components/edra/extensions/url-embed/UrlEmbed.ts
@@ -65,6 +65,9 @@ export const UrlEmbed = Node.create<UrlEmbedOptions>({
 			favicon: {
 				default: null
 			},
+			faviconMediaId: {
+				default: null
+			},
 			siteName: {
 				default: null
 			}

--- a/src/lib/server/enrich-url-embeds.ts
+++ b/src/lib/server/enrich-url-embeds.ts
@@ -1,5 +1,5 @@
 import { scrapeOgMetadata, type OgMetadata } from './og-metadata'
-import { downloadOgImage } from './og-image-download'
+import { downloadOgImage, type DownloadedOgImage } from './og-image-download'
 
 interface UrlEmbedAttrs {
 	url?: string
@@ -8,6 +8,7 @@ interface UrlEmbedAttrs {
 	image?: string
 	imageMediaId?: number
 	favicon?: string
+	faviconMediaId?: number
 	siteName?: string
 	[key: string]: unknown
 }
@@ -39,18 +40,26 @@ export async function enrichUrlEmbeds(content: unknown): Promise<void> {
 		[...unique.entries()].map(async ([url, targets]) => {
 			try {
 				const metadata = await scrapeOgMetadata(url)
-				const hosted =
-					metadata.image && !isLocallyHosted(metadata.image)
-						? await downloadOgImage(metadata.image, url)
-						: null
+				const [hostedImage, hostedFavicon] = await Promise.all([
+					downloadIfRemote(metadata.image, url),
+					downloadIfRemote(metadata.favicon, url)
+				])
 				for (const node of targets) {
-					applyMetadata(node, metadata, hosted)
+					applyMetadata(node, metadata, hostedImage, hostedFavicon)
 				}
 			} catch (err) {
 				console.error(`Failed to enrich urlEmbed for ${url}:`, err)
 			}
 		})
 	)
+}
+
+async function downloadIfRemote(
+	imageUrl: string | null,
+	referer: string
+): Promise<DownloadedOgImage | null> {
+	if (!imageUrl || isLocallyHosted(imageUrl)) return null
+	return downloadOgImage(imageUrl, referer)
 }
 
 function isLocallyHosted(imageUrl: string): boolean {
@@ -73,29 +82,36 @@ function collectMissing(node: RichTextNode, out: RichTextNode[]): void {
 
 function needsEnrichment(attrs: UrlEmbedAttrs): boolean {
 	if (!attrs.title) return true
-	if (!attrs.image) return true
-	// Legacy/hotlinked images should be re-hosted on our own storage.
-	if (!isLocallyHosted(attrs.image)) return true
+	if (!attrs.image || !isLocallyHosted(attrs.image)) return true
+	// Favicon is optional, but if present it should also be self-hosted.
+	if (attrs.favicon && !isLocallyHosted(attrs.favicon)) return true
 	return false
 }
 
 function applyMetadata(
 	node: RichTextNode,
 	metadata: OgMetadata,
-	hosted: { mediaId: number; url: string } | null
+	hostedImage: DownloadedOgImage | null,
+	hostedFavicon: DownloadedOgImage | null
 ): void {
 	const attrs: UrlEmbedAttrs = { ...(node.attrs ?? {}) }
 	if (!attrs.title && metadata.title) attrs.title = metadata.title
 	if (!attrs.description && metadata.description) attrs.description = metadata.description
 
-	if (hosted) {
-		attrs.image = hosted.url
-		attrs.imageMediaId = hosted.mediaId
+	if (hostedImage) {
+		attrs.image = hostedImage.url
+		attrs.imageMediaId = hostedImage.mediaId
 	} else if (!attrs.image && metadata.image) {
 		attrs.image = metadata.image
 	}
 
-	if (!attrs.favicon && metadata.favicon) attrs.favicon = metadata.favicon
+	if (hostedFavicon) {
+		attrs.favicon = hostedFavicon.url
+		attrs.faviconMediaId = hostedFavicon.mediaId
+	} else if (!attrs.favicon && metadata.favicon) {
+		attrs.favicon = metadata.favicon
+	}
+
 	if (!attrs.siteName && metadata.siteName) attrs.siteName = metadata.siteName
 	node.attrs = attrs
 }

--- a/src/lib/server/media-usage.ts
+++ b/src/lib/server/media-usage.ts
@@ -270,9 +270,14 @@ function extractMediaFromRichText(content: unknown): number[] {
 			}
 		}
 
-		// Handle urlEmbed link-card thumbnails that we downloaded into our media store
-		if (node.type === 'urlEmbed' && typeof node.attrs?.imageMediaId === 'number') {
-			mediaIds.push(node.attrs.imageMediaId as number)
+		// Handle urlEmbed link-card thumbnails and favicons that we downloaded into our media store
+		if (node.type === 'urlEmbed') {
+			if (typeof node.attrs?.imageMediaId === 'number') {
+				mediaIds.push(node.attrs.imageMediaId as number)
+			}
+			if (typeof node.attrs?.faviconMediaId === 'number') {
+				mediaIds.push(node.attrs.faviconMediaId as number)
+			}
 		}
 
 		// Recursively traverse child nodes

--- a/src/lib/server/og-image-download.ts
+++ b/src/lib/server/og-image-download.ts
@@ -119,6 +119,9 @@ function extFromContentType(contentType: string): string {
 			return 'avif'
 		case 'image/svg+xml':
 			return 'svg'
+		case 'image/x-icon':
+		case 'image/vnd.microsoft.icon':
+			return 'ico'
 		default:
 			return 'img'
 	}

--- a/src/routes/api/og-image-proxy/+server.ts
+++ b/src/routes/api/og-image-proxy/+server.ts
@@ -1,0 +1,87 @@
+import type { RequestHandler } from './$types'
+
+const FETCH_TIMEOUT_MS = 8000
+const MAX_BYTES = 10 * 1024 * 1024
+const BROWSER_UA =
+	'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36'
+
+/**
+ * Same-origin image proxy for og:image thumbnails so cross-origin urls don't trip
+ * our CSP (`img-src 'self'`). Kept strict to limit SSRF surface: http/https only,
+ * no private/loopback hosts, image content-type only, hard byte ceiling.
+ *
+ * This is a compatibility shim. New posts get their link-card images downloaded
+ * and stored as Media at save time — those render from /api/media/* directly
+ * and bypass the proxy entirely.
+ */
+export const GET: RequestHandler = async ({ url, fetch: svelteFetch, setHeaders }) => {
+	const src = url.searchParams.get('url')
+	if (!src) return new Response('missing url', { status: 400 })
+
+	let target: URL
+	try {
+		target = new URL(src)
+	} catch {
+		return new Response('invalid url', { status: 400 })
+	}
+
+	if (target.protocol !== 'https:' && target.protocol !== 'http:') {
+		return new Response('unsupported scheme', { status: 400 })
+	}
+	if (isDisallowedHost(target.hostname)) {
+		return new Response('disallowed host', { status: 400 })
+	}
+
+	const fetchFn = (typeof svelteFetch === 'function' ? svelteFetch : fetch) as typeof fetch
+	let upstream: Response
+	try {
+		upstream = await fetchFn(target.href, {
+			headers: { 'User-Agent': BROWSER_UA, Accept: 'image/*' },
+			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+			redirect: 'follow'
+		})
+	} catch {
+		return new Response('upstream fetch failed', { status: 502 })
+	}
+
+	if (!upstream.ok || !upstream.body) {
+		return new Response('upstream error', { status: 502 })
+	}
+
+	const contentType = (upstream.headers.get('content-type') || '').split(';')[0].trim()
+	if (!contentType.startsWith('image/')) {
+		return new Response('not an image', { status: 415 })
+	}
+
+	const contentLength = Number(upstream.headers.get('content-length') || '0')
+	if (contentLength > MAX_BYTES) {
+		return new Response('image too large', { status: 413 })
+	}
+
+	setHeaders({
+		'Content-Type': contentType,
+		'Cache-Control': 'public, max-age=86400, stale-while-revalidate=604800'
+	})
+
+	return new Response(upstream.body, { status: 200 })
+}
+
+function isDisallowedHost(hostname: string): boolean {
+	const h = hostname.toLowerCase()
+	if (h === 'localhost' || h === '' || h === '::1') return true
+	// Literal IPv4 checks — block loopback, private ranges, link-local, reserved.
+	const v4 = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/)
+	if (v4) {
+		const [a, b] = [Number(v4[1]), Number(v4[2])]
+		if (a === 10 || a === 127) return true
+		if (a === 169 && b === 254) return true
+		if (a === 172 && b >= 16 && b <= 31) return true
+		if (a === 192 && b === 168) return true
+		if (a === 0) return true
+	}
+	// IPv6 literals in URLs are bracketed; URL.hostname strips brackets.
+	if (h.includes(':') && (h.startsWith('fc') || h.startsWith('fd') || h.startsWith('fe80'))) {
+		return true
+	}
+	return false
+}

--- a/src/routes/api/og-metadata/+server.ts
+++ b/src/routes/api/og-metadata/+server.ts
@@ -20,18 +20,24 @@ export const GET: RequestHandler = async ({ url }) => {
 }
 
 /**
- * Rewrite the image url to point at our same-origin proxy so browsers with a
- * strict `img-src 'self'` CSP can still render the preview during editing.
- * Server-side callers (enrichUrlEmbeds) call `scrapeOgMetadata` directly and
- * keep the raw url, which is what gets downloaded into Media at save time.
+ * Rewrite remote image urls (og:image + favicon) to point at our same-origin
+ * proxy so browsers with a strict `img-src 'self'` CSP can still render the
+ * preview during editing. Server-side callers (enrichUrlEmbeds) call
+ * `scrapeOgMetadata` directly and keep the raw urls, which is what gets
+ * downloaded into Media at save time.
  */
 function proxyRemoteImage(metadata: OgMetadata): OgMetadata {
-	if (!metadata.image) return metadata
-	if (metadata.image.startsWith('/')) return metadata
 	return {
 		...metadata,
-		image: `/api/og-image-proxy?url=${encodeURIComponent(metadata.image)}`
+		image: toProxyUrl(metadata.image),
+		favicon: toProxyUrl(metadata.favicon)
 	}
+}
+
+function toProxyUrl(src: string | null): string | null {
+	if (!src) return src
+	if (src.startsWith('/')) return src
+	return `/api/og-image-proxy?url=${encodeURIComponent(src)}`
 }
 
 export const POST: RequestHandler = async ({ request }) => {

--- a/src/routes/api/og-metadata/+server.ts
+++ b/src/routes/api/og-metadata/+server.ts
@@ -1,6 +1,6 @@
 import { json } from '@sveltejs/kit'
 import type { RequestHandler } from './$types'
-import { scrapeOgMetadata } from '$lib/server/og-metadata'
+import { scrapeOgMetadata, type OgMetadata } from '$lib/server/og-metadata'
 
 export const GET: RequestHandler = async ({ url }) => {
 	const targetUrl = url.searchParams.get('url')
@@ -12,10 +12,25 @@ export const GET: RequestHandler = async ({ url }) => {
 
 	try {
 		const metadata = await scrapeOgMetadata(targetUrl, { forceRefresh })
-		return json(metadata)
+		return json(proxyRemoteImage(metadata))
 	} catch (error) {
 		console.error('Error fetching OpenGraph data:', error)
 		return json({ error: 'Failed to fetch metadata', url: targetUrl }, { status: 500 })
+	}
+}
+
+/**
+ * Rewrite the image url to point at our same-origin proxy so browsers with a
+ * strict `img-src 'self'` CSP can still render the preview during editing.
+ * Server-side callers (enrichUrlEmbeds) call `scrapeOgMetadata` directly and
+ * keep the raw url, which is what gets downloaded into Media at save time.
+ */
+function proxyRemoteImage(metadata: OgMetadata): OgMetadata {
+	if (!metadata.image) return metadata
+	if (metadata.image.startsWith('/')) return metadata
+	return {
+		...metadata,
+		image: `/api/og-image-proxy?url=${encodeURIComponent(metadata.image)}`
 	}
 }
 


### PR DESCRIPTION
## Summary
- adds `GET /api/og-image-proxy?url=<encoded>` that streams remote image bytes with strict guards (http(s) only, private/loopback hosts blocked, image content-type only, 10 MB ceiling, 8s timeout, 1-day cache)
- `GET /api/og-metadata` now rewrites both the `image` and `favicon` fields to proxy urls before returning
- `enrichUrlEmbeds` now downloads the favicon in parallel with the main image and stores it as a Media row with `faviconMediaId` on the urlEmbed node
- legacy posts with foreign favicon urls self-heal on re-save (same pattern as the image path)

## Why
after #82 the editor still showed raw third-party `og:image` urls during editing, which our `img-src 'self' ...` CSP blocks. Same issue hits legacy posts on public pages saved before #82, and the favicon path had the exact same hotlink problem that the image path had.

## Deployment note
**#82's migration (`20260422000000_add_media_link_card_flag`) must be applied** before this change is useful — without it, save-time `Media.create()` throws because `isLinkCardImage` doesn't exist in the DB, so downloads silently fall through to the hotlink path.

```
npm run db:deploy
```

## Test plan
- [ ] editor: paste a url, confirm both the preview image and favicon load via `/api/og-image-proxy?url=...` and no CSP violation fires
- [ ] save the post, confirm `content.urlEmbed.attrs.image` and `.favicon` are both `/api/media/<id>` urls
- [ ] confirm new `Media` rows for both have `isLinkCardImage = true` (so they stay hidden from the library)
- [ ] open a post saved before #82 (raw hotlinks in attrs) — proxy handles the render; re-saving upgrades both to hosted urls
- [ ] broken/403 source favicon → save still succeeds; attrs keep whatever was there as fallback
- [ ] `/api/og-image-proxy?url=http://localhost:22` → 400 disallowed
- [ ] `/api/og-image-proxy?url=file:///etc/passwd` → 400 unsupported scheme
- [ ] `/api/og-image-proxy?url=https://example.com/huge.png` with `content-length > 10MB` → 413
- [ ] `/api/og-image-proxy?url=https://example.com/page.html` (non-image) → 415