### PR TITLE
add garden posts to rss feeds

### DIFF
--- a/prisma/migrations/20260422120000_garden_show_in_universe/migration.sql
+++ b/prisma/migrations/20260422120000_garden_show_in_universe/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "GardenItem" ADD COLUMN "showInUniverse" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -266,6 +266,7 @@ model GardenItem {
   rating         Int?
   isCurrent      Boolean   @default(false)
   isFavorite     Boolean   @default(false)
+  showInUniverse Boolean   @default(false)
   status         String    @default("draft") @db.VarChar(50)
   publishedAt    DateTime?
   displayOrder   Int       @default(0)

--- a/src/lib/components/admin/GardenItemForm.svelte
+++ b/src/lib/components/admin/GardenItemForm.svelte
@@ -49,6 +49,7 @@
 	let rating = $state<number | null>(item?.rating ?? null)
 	let isCurrent = $state(item?.isCurrent ?? false)
 	let isFavorite = $state(item?.isFavorite ?? false)
+	let showInUniverse = $state(item?.showInUniverse ?? false)
 	let status = $state<'draft' | 'published'>((item?.status as 'draft' | 'published') ?? 'draft')
 	let note = $state<JSONContent>(
 		(item?.note as JSONContent) ?? { type: 'doc', content: [{ type: 'paragraph' }] }
@@ -106,6 +107,7 @@
 		rating: item?.rating ?? null,
 		isCurrent: item?.isCurrent ?? false,
 		isFavorite: item?.isFavorite ?? false,
+		showInUniverse: item?.showInUniverse ?? false,
 		status: (item?.status as 'draft' | 'published') ?? 'draft',
 		note: JSON.stringify(
 			(item?.note as JSONContent) ?? { type: 'doc', content: [{ type: 'paragraph' }] }
@@ -125,6 +127,7 @@
 			rating !== original.rating ||
 			isCurrent !== original.isCurrent ||
 			isFavorite !== original.isFavorite ||
+			showInUniverse !== original.showInUniverse ||
 			status !== original.status ||
 			JSON.stringify(note) !== original.note
 	)
@@ -281,6 +284,7 @@
 				rating,
 				isCurrent,
 				isFavorite,
+				showInUniverse,
 				status: saveStatus,
 				note: note && note.content && note.content.length > 0 ? note : null,
 				updatedAt: mode === 'edit' ? item?.updatedAt : undefined
@@ -310,6 +314,7 @@
 				rating: savedItem.rating ?? null,
 				isCurrent: savedItem.isCurrent,
 				isFavorite: savedItem.isFavorite,
+				showInUniverse: savedItem.showInUniverse,
 				status: savedItem.status as 'draft' | 'published',
 				note: JSON.stringify(savedItem.note ?? { type: 'doc', content: [{ type: 'paragraph' }] })
 			}
@@ -398,6 +403,7 @@
 				rating,
 				isCurrent,
 				isFavorite,
+				showInUniverse,
 				status,
 				note: JSON.stringify(note)
 			}
@@ -524,6 +530,16 @@
 								<span class="switch-description">This one's a banger</span>
 							</div>
 							<Switch bind:checked={isFavorite} />
+						</div>
+
+						<div class="switch-field">
+							<div class="switch-info">
+								<span class="switch-label">Show in Universe</span>
+								<span class="switch-description"
+									>Include this Garden post in the jedmund.com Everything feed</span
+								>
+							</div>
+							<Switch bind:checked={showInUniverse} />
 						</div>
 					</form>
 				</div>

--- a/src/lib/server/rss/helpers.ts
+++ b/src/lib/server/rss/helpers.ts
@@ -1,0 +1,84 @@
+import type { Prisma } from '@prisma/client'
+import { renderEdraContent } from '$lib/utils/content'
+
+interface TextNode {
+	type: 'text'
+	text: string
+	marks?: unknown[]
+}
+
+interface ParagraphNode {
+	type: 'paragraph'
+	content?: (TextNode | ContentNode)[]
+}
+
+interface ContentNode {
+	type: string
+	content?: ContentNode[]
+	attrs?: Record<string, unknown>
+}
+
+interface DocContent {
+	type: 'doc'
+	content?: ContentNode[]
+}
+
+export function escapeXML(str: string): string {
+	if (!str) return ''
+	return str
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;')
+}
+
+export function formatRFC822Date(date: Date): string {
+	return date.toUTCString()
+}
+
+export function convertContentToHTML(content: Prisma.JsonValue): string {
+	if (!content) return ''
+
+	if (typeof content === 'string') {
+		return `<p>${escapeXML(content)}</p>`
+	}
+
+	return renderEdraContent(content)
+}
+
+export function extractTextSummary(content: Prisma.JsonValue, maxLength: number = 300): string {
+	if (!content) return ''
+
+	let text = ''
+
+	if (typeof content === 'string') {
+		text = content
+	} else if (
+		typeof content === 'object' &&
+		content !== null &&
+		'type' in content &&
+		content.type === 'doc' &&
+		'content' in content &&
+		Array.isArray(content.content)
+	) {
+		const docContent = content as unknown as DocContent
+		text =
+			docContent.content
+				?.filter((node): node is ParagraphNode => node.type === 'paragraph')
+				.map((node) => {
+					if (node.content && Array.isArray(node.content)) {
+						return node.content
+							.filter((child): child is TextNode => 'type' in child && child.type === 'text')
+							.map((child) => child.text || '')
+							.join('')
+					}
+					return ''
+				})
+				.filter((t) => t.length > 0)
+				.join(' ') || ''
+	}
+
+	text = text.replace(/\s+/g, ' ').trim()
+	return text.length > maxLength ? text.substring(0, maxLength) + '...' : text
+}

--- a/src/routes/api/admin/garden/+server.ts
+++ b/src/routes/api/admin/garden/+server.ts
@@ -20,6 +20,7 @@ interface GardenItemCreateBody {
 	rating?: number
 	isCurrent?: boolean
 	isFavorite?: boolean
+	showInUniverse?: boolean
 	displayOrder?: number
 	status?: string
 }
@@ -84,6 +85,7 @@ export const POST: RequestHandler = async (event) => {
 				rating: body.rating != null ? Math.min(5, Math.max(1, body.rating)) : null,
 				isCurrent: body.isCurrent ?? false,
 				isFavorite: body.isFavorite ?? false,
+				showInUniverse: body.showInUniverse ?? false,
 				displayOrder: body.displayOrder ?? 0,
 				status,
 				publishedAt: status === 'published' ? new Date() : null

--- a/src/routes/api/admin/garden/[id]/+server.ts
+++ b/src/routes/api/admin/garden/[id]/+server.ts
@@ -21,6 +21,7 @@ interface GardenItemUpdateBody {
 	rating?: number | null
 	isCurrent?: boolean
 	isFavorite?: boolean
+	showInUniverse?: boolean
 	displayOrder?: number
 	status?: string
 	updatedAt?: string
@@ -140,6 +141,7 @@ export const PUT: RequestHandler = async (event) => {
 						: existing.rating,
 				isCurrent: body.isCurrent ?? existing.isCurrent,
 				isFavorite: body.isFavorite ?? existing.isFavorite,
+				showInUniverse: body.showInUniverse ?? existing.showInUniverse,
 				displayOrder: body.displayOrder ?? existing.displayOrder,
 				status: newStatus,
 				publishedAt

--- a/src/routes/feeds/+page.svelte
+++ b/src/routes/feeds/+page.svelte
@@ -24,6 +24,11 @@
 			name: 'Photos',
 			url: '/rss/photos',
 			description: 'Photo albums and standalone photos.'
+		},
+		{
+			name: 'Garden',
+			url: '/rss/garden',
+			description: 'Books, movies, games, music, and more — with notes and ratings.'
 		}
 	]
 </script>

--- a/src/routes/rss/+server.ts
+++ b/src/routes/rss/+server.ts
@@ -1,95 +1,13 @@
 import type { RequestHandler } from './$types'
-import type { Prisma } from '@prisma/client'
+import { Prisma } from '@prisma/client'
 import { prisma } from '$lib/server/database'
 import { logger } from '$lib/server/logger'
-import { renderEdraContent } from '$lib/utils/content'
-
-// Content node types for TipTap/Edra content
-interface TextNode {
-	type: 'text'
-	text: string
-	marks?: unknown[]
-}
-
-interface ParagraphNode {
-	type: 'paragraph'
-	content?: (TextNode | ContentNode)[]
-}
-
-interface ContentNode {
-	type: string
-	content?: ContentNode[]
-	attrs?: Record<string, unknown>
-}
-
-interface DocContent {
-	type: 'doc'
-	content?: ContentNode[]
-}
-
-// Helper function to escape XML special characters
-function escapeXML(str: string): string {
-	if (!str) return ''
-	return str
-		.replace(/&/g, '&amp;')
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;')
-		.replace(/"/g, '&quot;')
-		.replace(/'/g, '&#39;')
-}
-
-// Helper function to convert content to HTML for full content
-function convertContentToHTML(content: Prisma.JsonValue): string {
-	if (!content) return ''
-
-	if (typeof content === 'string') {
-		return `<p>${escapeXML(content)}</p>`
-	}
-
-	return renderEdraContent(content)
-}
-
-// Helper function to extract text summary from content
-function extractTextSummary(content: Prisma.JsonValue, maxLength: number = 300): string {
-	if (!content) return ''
-
-	let text = ''
-
-	if (typeof content === 'string') {
-		text = content
-	} else if (
-		typeof content === 'object' &&
-		content !== null &&
-		'type' in content &&
-		content.type === 'doc' &&
-		'content' in content &&
-		Array.isArray(content.content)
-	) {
-		const docContent = content as unknown as DocContent
-		text =
-			docContent.content
-				?.filter((node): node is ParagraphNode => node.type === 'paragraph')
-				.map((node) => {
-					if (node.content && Array.isArray(node.content)) {
-						return node.content
-							.filter((child): child is TextNode => 'type' in child && child.type === 'text')
-							.map((child) => child.text || '')
-							.join('')
-					}
-					return ''
-				})
-				.filter((t) => t.length > 0)
-				.join(' ') || ''
-	}
-
-	text = text.replace(/\s+/g, ' ').trim()
-	return text.length > maxLength ? text.substring(0, maxLength) + '...' : text
-}
-
-// Helper function to format RFC 822 date
-function formatRFC822Date(date: Date): string {
-	return date.toUTCString()
-}
+import {
+	escapeXML,
+	formatRFC822Date,
+	extractTextSummary,
+	convertContentToHTML
+} from '$lib/server/rss/helpers'
 
 export const GET: RequestHandler = async (event) => {
 	try {
@@ -116,6 +34,17 @@ export const GET: RequestHandler = async (event) => {
 			},
 			orderBy: { createdAt: 'desc' },
 			take: 25
+		})
+
+		// Get published garden items with notes that opt into the Everything feed
+		const gardenItems = await prisma.gardenItem.findMany({
+			where: {
+				status: 'published',
+				showInUniverse: true,
+				note: { not: Prisma.DbNull }
+			},
+			orderBy: [{ publishedAt: 'desc' }, { createdAt: 'desc' }],
+			take: 50
 		})
 
 		// Combine and sort by date
@@ -155,6 +84,20 @@ export const GET: RequestHandler = async (event) => {
 				updatedDate: album.updatedAt,
 				postType: 'album' as const,
 				featuredImage: null
+			})),
+			...gardenItems.map((item) => ({
+				type: 'garden' as const,
+				section: 'garden',
+				id: item.id.toString(),
+				title: item.title,
+				description: extractTextSummary(item.note) || item.summary || '',
+				content: convertContentToHTML(item.note),
+				link: `${event.url.origin}/garden/${item.category}/${item.slug}`,
+				guid: `${event.url.origin}/garden/${item.category}/${item.slug}`,
+				pubDate: item.publishedAt || item.createdAt,
+				updatedDate: item.updatedAt,
+				postType: item.category,
+				featuredImage: item.imageUrl
 			}))
 		].sort((a, b) => new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime())
 

--- a/src/routes/rss/garden/+server.ts
+++ b/src/routes/rss/garden/+server.ts
@@ -1,0 +1,97 @@
+import type { RequestHandler } from './$types'
+import { Prisma } from '@prisma/client'
+import { prisma } from '$lib/server/database'
+import { logger } from '$lib/server/logger'
+import {
+	escapeXML,
+	formatRFC822Date,
+	extractTextSummary,
+	convertContentToHTML
+} from '$lib/server/rss/helpers'
+
+export const GET: RequestHandler = async (event) => {
+	try {
+		const items = await prisma.gardenItem.findMany({
+			where: {
+				status: 'published',
+				note: { not: Prisma.DbNull }
+			},
+			orderBy: [{ publishedAt: 'desc' }, { createdAt: 'desc' }],
+			take: 50
+		})
+
+		const now = new Date()
+		const lastBuildDate = formatRFC822Date(now)
+
+		const rssXml = `<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet href="/rss.xsl" type="text/xsl"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+<channel>
+<title>Garden - jedmund.com</title>
+<description>Books, movies, games, music, TV, and manga I've been enjoying, with notes and ratings.</description>
+<link>${event.url.origin}/garden</link>
+<atom:link href="${event.url.origin}/rss/garden" rel="self" type="application/rss+xml"/>
+<language>en-us</language>
+<lastBuildDate>${lastBuildDate}</lastBuildDate>
+<managingEditor>noreply@jedmund.com (Justin Edmund)</managingEditor>
+<webMaster>noreply@jedmund.com (Justin Edmund)</webMaster>
+<generator>SvelteKit RSS Generator</generator>
+<docs>https://cyber.harvard.edu/rss/rss.html</docs>
+<ttl>60</ttl>
+${items
+	.map((item) => {
+		const link = `${event.url.origin}/garden/${item.category}/${item.slug}`
+		const description = extractTextSummary(item.note) || item.summary || ''
+		const content = convertContentToHTML(item.note)
+		const pubDate = item.publishedAt || item.createdAt
+		const imageUrl = item.imageUrl
+			? item.imageUrl.startsWith('http')
+				? item.imageUrl
+				: event.url.origin + item.imageUrl
+			: null
+
+		return `
+<item>
+<title>${escapeXML(item.title)}</title>
+<description><![CDATA[${description}]]></description>
+${content ? `<content:encoded><![CDATA[${content}]]></content:encoded>` : ''}
+<link>${link}</link>
+<guid isPermaLink="true">${link}</guid>
+<pubDate>${formatRFC822Date(new Date(pubDate))}</pubDate>
+<atom:updated>${new Date(item.updatedAt).toISOString()}</atom:updated>
+<category>${escapeXML(item.category)}</category>
+${item.creator ? `<category domain="creator">${escapeXML(item.creator)}</category>` : ''}
+${item.rating ? `<category domain="rating">${item.rating}/5</category>` : ''}
+${item.isFavorite ? `<category>favorite</category>` : ''}
+${item.isCurrent ? `<category>current</category>` : ''}
+${
+	imageUrl
+		? `
+<enclosure url="${imageUrl}" type="image/jpeg" length="0"/>
+<media:content url="${imageUrl}" type="image/jpeg"/>`
+		: ''
+}
+<author>noreply@jedmund.com (Justin Edmund)</author>
+</item>`
+	})
+	.join('')}
+</channel>
+</rss>`
+
+		logger.info('Garden RSS feed generated', { itemCount: items.length })
+
+		return new Response(rssXml, {
+			headers: {
+				'Content-Type': 'application/xml; charset=utf-8',
+				'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+				'Last-Modified': lastBuildDate,
+				ETag: `"${Buffer.from(rssXml).toString('base64').slice(0, 16)}"`,
+				'X-Content-Type-Options': 'nosniff',
+				Vary: 'Accept-Encoding'
+			}
+		})
+	} catch (error) {
+		logger.error('Failed to generate Garden RSS feed', error as Error)
+		return new Response('Failed to generate RSS feed', { status: 500 })
+	}
+}

--- a/src/routes/rss/photos/+server.ts
+++ b/src/routes/rss/photos/+server.ts
@@ -1,22 +1,7 @@
 import type { RequestHandler } from './$types'
 import { prisma } from '$lib/server/database'
 import { logger } from '$lib/server/logger'
-
-// Helper function to escape XML special characters
-function escapeXML(str: string): string {
-	if (!str) return ''
-	return str
-		.replace(/&/g, '&amp;')
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;')
-		.replace(/"/g, '&quot;')
-		.replace(/'/g, '&#39;')
-}
-
-// Helper function to format RFC 822 date
-function formatRFC822Date(date: Date): string {
-	return date.toUTCString()
-}
+import { escapeXML, formatRFC822Date } from '$lib/server/rss/helpers'
 
 interface AlbumItem {
 	type: 'album'


### PR DESCRIPTION
## Summary

- Garden posts now show up in RSS. Published items with a `note` appear in a new `/rss/garden` feed; items also flagged `showInUniverse` promote into the main `/rss` "Everything" feed without creating a duplicate Post.
- New **Show in Universe** toggle on the Garden composer (mirrors the Album pattern). Backed by a new `GardenItem.showInUniverse` column (default `false`) + migration, threaded through the admin create/update endpoints.
- Extracted the duplicated RSS helpers (`escapeXML`, `formatRFC822Date`, `extractTextSummary`, `convertContentToHTML`) into `src/lib/server/rss/helpers.ts` so all three feed handlers share them.
- Listed the new Garden feed on `/feeds`.

Only items with real commentary (non-null `note`) go into either feed — bare catalog entries stay out.

## Test plan

- [ ] Run `npx prisma migrate dev` to apply `20260422120000_garden_show_in_universe`
- [ ] In the admin, edit a published Garden item with a note, toggle **Show in Universe** on, save; edit another, leave it off
- [ ] `GET /rss/garden` — both items present, note rendered as HTML, imageUrl as enclosure, link to `/garden/{category}/{slug}`, categories include creator/rating/favorite/current
- [ ] `GET /rss` — only the opted-in item appears among Garden entries, interleaved with Posts/Albums by date
- [ ] `GET /feeds` — Garden feed listed with working Subscribe link
- [ ] Duplication check: promoted Garden item shows once (Garden entry), no shadow Post created
- [ ] Confirm `/rss` and `/rss/photos` still byte-for-byte equivalent aside from the new Garden items (helper extraction is a mechanical move)
- [ ] Validate new feed XML at https://validator.w3.org/feed/