### PR TITLE
show garden posts on /universe + video heroes for essay previews

### DIFF
--- a/src/lib/components/UniverseCard.svelte
+++ b/src/lib/components/UniverseCard.svelte
@@ -2,6 +2,7 @@
 	import type { Snippet } from 'svelte'
 	import UniverseIcon from '$icons/universe.svg?component'
 	import PhotosIcon from '$icons/photos.svg?component'
+	import GardenIcon from '$icons/garden.svg?component'
 	import { formatDate } from '$lib/utils/date'
 	import { goto } from '$app/navigation'
 
@@ -62,6 +63,8 @@
 			</a>
 			{#if type === 'album'}
 				<PhotosIcon class="card-icon" />
+			{:else if type === 'garden'}
+				<GardenIcon class="card-icon" />
 			{:else}
 				<UniverseIcon class="card-icon" />
 			{/if}

--- a/src/lib/components/UniverseCard.svelte
+++ b/src/lib/components/UniverseCard.svelte
@@ -14,14 +14,18 @@
 	let {
 		item,
 		type = 'post',
+		href: hrefOverride,
 		children
 	}: {
 		item: UniverseItem
-		type?: 'post' | 'album'
+		type?: 'post' | 'album' | 'garden'
+		href?: string
 		children?: Snippet
 	} = $props()
 
-	const href = $derived(type === 'album' ? `/photos/${item.slug}` : `/universe/${item.slug}`)
+	const href = $derived(
+		hrefOverride ?? (type === 'album' ? `/photos/${item.slug}` : `/universe/${item.slug}`)
+	)
 
 	const handleCardClick = (event: MouseEvent) => {
 		// Check if the click is on an interactive element
@@ -121,7 +125,8 @@
 		transition: all $transition-normal ease;
 	}
 
-	.universe-card--post {
+	.universe-card--post,
+	.universe-card--garden {
 		.card-content:hover {
 			.card-date {
 				color: $red-60;

--- a/src/lib/components/UniverseCard.svelte
+++ b/src/lib/components/UniverseCard.svelte
@@ -135,11 +135,6 @@
 				color: $red-60;
 			}
 
-			:global(.card-icon) {
-				fill: $red-60;
-				transform: rotate(15deg);
-			}
-
 			:global(.card-title-link) {
 				color: $red-60;
 			}
@@ -149,6 +144,24 @@
 			color: $gray-10;
 			text-decoration: none;
 			transition: all $transition-normal ease;
+		}
+	}
+
+	.universe-card--post {
+		.card-content:hover :global(.card-icon) {
+			fill: $red-60;
+			transform: rotate(15deg);
+		}
+	}
+
+	.universe-card--garden {
+		:global(.card-icon) {
+			transform-origin: center bottom;
+		}
+
+		.card-content:hover :global(.card-icon) {
+			fill: $red-60;
+			animation: leafSway 0.6s ease;
 		}
 	}
 

--- a/src/lib/components/UniverseFeed.svelte
+++ b/src/lib/components/UniverseFeed.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import UniversePostCard from './UniversePostCard.svelte'
 	import UniverseAlbumCard from './UniverseAlbumCard.svelte'
+	import UniverseGardenCard from './UniverseGardenCard.svelte'
 	import type { UniverseItem } from '../../routes/api/universe/+server'
 
 	let { items }: { items: UniverseItem[] } = $props()
@@ -13,6 +14,8 @@
 				<UniversePostCard post={item} />
 			{:else if item.type === 'album'}
 				<UniverseAlbumCard album={item} />
+			{:else if item.type === 'garden'}
+				<UniverseGardenCard garden={item} />
 			{/if}
 		{/each}
 	{:else}

--- a/src/lib/components/UniverseGardenCard.svelte
+++ b/src/lib/components/UniverseGardenCard.svelte
@@ -35,7 +35,7 @@
 
 			{#if excerpt.html}
 				<p class="card-excerpt">
-					{@html excerpt.html}{#if excerpt.truncated}...&nbsp;<a
+					{@html excerpt.html}{#if excerpt.truncated}&nbsp;...&nbsp;<a
 							{href}
 							class="read-more"
 							tabindex="-1">Continue reading</a

--- a/src/lib/components/UniverseGardenCard.svelte
+++ b/src/lib/components/UniverseGardenCard.svelte
@@ -64,6 +64,7 @@
 		border-radius: $image-corner-radius;
 		overflow: hidden;
 		background: $gray-95;
+		border: 2px solid rgba(0, 0, 0, 0.01);
 		display: block;
 
 		@include breakpoint('phone') {

--- a/src/lib/components/UniverseGardenCard.svelte
+++ b/src/lib/components/UniverseGardenCard.svelte
@@ -34,12 +34,10 @@
 			{/if}
 
 			{#if excerpt.html}
-				<div class="card-excerpt">{@html excerpt.html}</div>
-			{/if}
-
-			{#if excerpt.truncated}
-				<p>
-					<a {href} class="read-more" tabindex="-1">Continue reading</a>
+				<p class="card-excerpt">
+					{@html excerpt.html}{#if excerpt.truncated}&nbsp;<a {href} class="read-more" tabindex="-1"
+							>Continue reading</a
+						>{/if}
 				</p>
 			{/if}
 		</div>
@@ -97,13 +95,10 @@
 	}
 
 	.card-excerpt {
+		margin: 0;
 		color: $gray-10;
 		font-size: 1rem;
 		line-height: 1.5;
-
-		:global(p) {
-			margin: 0;
-		}
 
 		:global(a) {
 			color: $red-60;
@@ -116,11 +111,13 @@
 	}
 
 	.read-more {
-		display: inline-block;
-		margin-top: $unit;
 		color: $red-60;
 		text-decoration: none;
-		font-size: 0.875rem;
+		font-size: inherit;
 		font-weight: 500;
+
+		&:hover {
+			text-decoration: underline;
+		}
 	}
 </style>

--- a/src/lib/components/UniverseGardenCard.svelte
+++ b/src/lib/components/UniverseGardenCard.svelte
@@ -8,7 +8,7 @@
 	const href = $derived(`/garden/${garden.category}/${garden.slug}`)
 
 	const excerpt = $derived(
-		garden.content ? renderInlineExcerpt(garden.content, 220) : { html: '', truncated: false }
+		garden.content ? renderInlineExcerpt(garden.content) : { html: '', truncated: false }
 	)
 </script>
 
@@ -100,18 +100,9 @@
 		color: $gray-10;
 		font-size: 1rem;
 		line-height: 1.5;
-		display: -webkit-box;
-		-webkit-box-orient: vertical;
-		-webkit-line-clamp: 3;
-		line-clamp: 3;
-		overflow: hidden;
 
 		:global(p) {
 			margin: 0;
-		}
-
-		:global(p + p) {
-			margin-top: $unit;
 		}
 
 		:global(a) {

--- a/src/lib/components/UniverseGardenCard.svelte
+++ b/src/lib/components/UniverseGardenCard.svelte
@@ -61,7 +61,7 @@
 	.hero-image {
 		flex-shrink: 0;
 		max-width: 140px;
-		border-radius: $image-corner-radius;
+		border-radius: 4px;
 		overflow: hidden;
 		background: $gray-95;
 		border: 2px solid rgba(0, 0, 0, 0.01);

--- a/src/lib/components/UniverseGardenCard.svelte
+++ b/src/lib/components/UniverseGardenCard.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
 	import UniverseCard from './UniverseCard.svelte'
-	import { getContentExcerpt } from '$lib/utils/content'
+	import { renderInlineExcerpt } from '$lib/utils/content'
 	import type { UniverseItem } from '../../routes/api/universe/+server'
 
 	let { garden }: { garden: UniverseItem } = $props()
 
 	const href = $derived(`/garden/${garden.category}/${garden.slug}`)
 
-	const excerpt = $derived(garden.content ? getContentExcerpt(garden.content, 220) : '')
-
-	const isContentTruncated = $derived(excerpt.endsWith('...'))
+	const excerpt = $derived(
+		garden.content ? renderInlineExcerpt(garden.content, 220) : { html: '', truncated: false }
+	)
 </script>
 
 <UniverseCard
@@ -33,13 +33,13 @@
 				<p class="card-creator">{garden.creator}</p>
 			{/if}
 
-			{#if excerpt}
-				<p class="card-excerpt">{excerpt}</p>
+			{#if excerpt.html}
+				<div class="card-excerpt">{@html excerpt.html}</div>
 			{/if}
 
-			{#if isContentTruncated}
+			{#if excerpt.truncated}
 				<p>
-					<a {href} class="read-more" tabindex="-1">Read more</a>
+					<a {href} class="read-more" tabindex="-1">Continue reading</a>
 				</p>
 			{/if}
 		</div>
@@ -97,7 +97,6 @@
 	}
 
 	.card-excerpt {
-		margin: 0;
 		color: $gray-10;
 		font-size: 1rem;
 		line-height: 1.5;
@@ -106,6 +105,23 @@
 		-webkit-line-clamp: 3;
 		line-clamp: 3;
 		overflow: hidden;
+
+		:global(p) {
+			margin: 0;
+		}
+
+		:global(p + p) {
+			margin-top: $unit;
+		}
+
+		:global(a) {
+			color: $red-60;
+			text-decoration: none;
+		}
+
+		:global(a:hover) {
+			text-decoration: underline;
+		}
 	}
 
 	.read-more {

--- a/src/lib/components/UniverseGardenCard.svelte
+++ b/src/lib/components/UniverseGardenCard.svelte
@@ -10,25 +10,6 @@
 	const excerpt = $derived(garden.content ? getContentExcerpt(garden.content, 220) : '')
 
 	const isContentTruncated = $derived(excerpt.endsWith('...'))
-
-	const categoryLabel = $derived.by(() => {
-		switch (garden.category) {
-			case 'books':
-				return 'Book'
-			case 'movies':
-				return 'Movie'
-			case 'games':
-				return 'Game'
-			case 'music':
-				return 'Music'
-			case 'tv':
-				return 'TV'
-			case 'manga':
-				return 'Manga'
-			default:
-				return garden.category ?? ''
-		}
-	})
 </script>
 
 <UniverseCard
@@ -36,13 +17,6 @@
 	type="garden"
 	{href}
 >
-	<div class="card-header">
-		<span class="garden-eyebrow">
-			{categoryLabel}{#if garden.isFavorite}&nbsp;· Favorite{/if}{#if garden.isCurrent}&nbsp;·
-				Currently enjoying{/if}
-		</span>
-	</div>
-
 	<div class="card-body">
 		{#if garden.imageUrl}
 			<a {href} class="hero-image" tabindex="-1">
@@ -73,18 +47,6 @@
 </UniverseCard>
 
 <style lang="scss">
-	.card-header {
-		margin-bottom: $unit-2x;
-	}
-
-	.garden-eyebrow {
-		font-size: 0.8125rem;
-		font-weight: 500;
-		color: $gray-40;
-		text-transform: uppercase;
-		letter-spacing: 0.04em;
-	}
-
 	.card-body {
 		display: flex;
 		gap: $unit-3x;
@@ -98,22 +60,20 @@
 
 	.hero-image {
 		flex-shrink: 0;
-		width: 140px;
-		aspect-ratio: 2 / 3;
+		max-width: 140px;
 		border-radius: $image-corner-radius;
 		overflow: hidden;
 		background: $gray-95;
 		display: block;
 
 		@include breakpoint('phone') {
-			width: 100%;
-			aspect-ratio: 16 / 9;
+			max-width: 100%;
 		}
 
 		img {
+			display: block;
 			width: 100%;
-			height: 100%;
-			object-fit: cover;
+			height: auto;
 		}
 	}
 

--- a/src/lib/components/UniverseGardenCard.svelte
+++ b/src/lib/components/UniverseGardenCard.svelte
@@ -1,0 +1,158 @@
+<script lang="ts">
+	import UniverseCard from './UniverseCard.svelte'
+	import { getContentExcerpt } from '$lib/utils/content'
+	import type { UniverseItem } from '../../routes/api/universe/+server'
+
+	let { garden }: { garden: UniverseItem } = $props()
+
+	const href = $derived(`/garden/${garden.category}/${garden.slug}`)
+
+	const excerpt = $derived(garden.content ? getContentExcerpt(garden.content, 220) : '')
+
+	const isContentTruncated = $derived(excerpt.endsWith('...'))
+
+	const categoryLabel = $derived.by(() => {
+		switch (garden.category) {
+			case 'books':
+				return 'Book'
+			case 'movies':
+				return 'Movie'
+			case 'games':
+				return 'Game'
+			case 'music':
+				return 'Music'
+			case 'tv':
+				return 'TV'
+			case 'manga':
+				return 'Manga'
+			default:
+				return garden.category ?? ''
+		}
+	})
+</script>
+
+<UniverseCard
+	item={garden as unknown as { slug: string; publishedAt: string; [key: string]: unknown }}
+	type="garden"
+	{href}
+>
+	<div class="card-header">
+		<span class="garden-eyebrow">
+			{categoryLabel}{#if garden.isFavorite}&nbsp;· Favorite{/if}{#if garden.isCurrent}&nbsp;·
+				Currently enjoying{/if}
+		</span>
+	</div>
+
+	<div class="card-body">
+		{#if garden.imageUrl}
+			<a {href} class="hero-image" tabindex="-1">
+				<img src={garden.imageUrl} alt={garden.title ?? ''} loading="lazy" />
+			</a>
+		{/if}
+
+		<div class="card-text">
+			<h2 class="card-title">
+				<a {href} class="card-title-link" tabindex="-1">{garden.title}</a>
+			</h2>
+
+			{#if garden.creator}
+				<p class="card-creator">{garden.creator}</p>
+			{/if}
+
+			{#if excerpt}
+				<p class="card-excerpt">{excerpt}</p>
+			{/if}
+
+			{#if isContentTruncated}
+				<p>
+					<a {href} class="read-more" tabindex="-1">Read more</a>
+				</p>
+			{/if}
+		</div>
+	</div>
+</UniverseCard>
+
+<style lang="scss">
+	.card-header {
+		margin-bottom: $unit-2x;
+	}
+
+	.garden-eyebrow {
+		font-size: 0.8125rem;
+		font-weight: 500;
+		color: $gray-40;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+
+	.card-body {
+		display: flex;
+		gap: $unit-3x;
+		align-items: flex-start;
+
+		@include breakpoint('phone') {
+			flex-direction: column;
+			gap: $unit-2x;
+		}
+	}
+
+	.hero-image {
+		flex-shrink: 0;
+		width: 140px;
+		aspect-ratio: 2 / 3;
+		border-radius: $image-corner-radius;
+		overflow: hidden;
+		background: $gray-95;
+		display: block;
+
+		@include breakpoint('phone') {
+			width: 100%;
+			aspect-ratio: 16 / 9;
+		}
+
+		img {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+		}
+	}
+
+	.card-text {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.card-title {
+		margin: 0 0 $unit-half;
+		font-size: 1.25rem;
+		font-weight: 600;
+		line-height: 1.3;
+	}
+
+	.card-creator {
+		margin: 0 0 $unit-2x;
+		color: $gray-40;
+		font-size: 0.9375rem;
+	}
+
+	.card-excerpt {
+		margin: 0;
+		color: $gray-10;
+		font-size: 1rem;
+		line-height: 1.5;
+		display: -webkit-box;
+		-webkit-box-orient: vertical;
+		-webkit-line-clamp: 3;
+		line-clamp: 3;
+		overflow: hidden;
+	}
+
+	.read-more {
+		display: inline-block;
+		margin-top: $unit;
+		color: $red-60;
+		text-decoration: none;
+		font-size: 0.875rem;
+		font-weight: 500;
+	}
+</style>

--- a/src/lib/components/UniverseGardenCard.svelte
+++ b/src/lib/components/UniverseGardenCard.svelte
@@ -35,8 +35,10 @@
 
 			{#if excerpt.html}
 				<p class="card-excerpt">
-					{@html excerpt.html}{#if excerpt.truncated}&nbsp;<a {href} class="read-more" tabindex="-1"
-							>Continue reading</a
+					{@html excerpt.html}{#if excerpt.truncated}...&nbsp;<a
+							{href}
+							class="read-more"
+							tabindex="-1">Continue reading</a
 						>{/if}
 				</p>
 			{/if}

--- a/src/lib/components/UniversePostCard.svelte
+++ b/src/lib/components/UniversePostCard.svelte
@@ -142,7 +142,13 @@
 			bind:this={excerptEl}
 		>
 			{#if post.postType === 'essay'}
-				{@html essayExcerpt.html}
+				<p>
+					{@html essayExcerpt.html}{#if essayExcerpt.truncated}&nbsp;<a
+							href="/universe/{post.slug}"
+							class="read-more"
+							tabindex="-1">Continue reading</a
+						>{/if}
+				</p>
 			{:else}
 				{@html renderEdraContent(post.content)}
 			{/if}
@@ -155,12 +161,6 @@
 				<TagPill {tag} size="small" href="/universe?tags={tag.slug}" />
 			{/each}
 		</div>
-	{/if}
-
-	{#if post.postType === 'essay' && essayExcerpt.truncated}
-		<p>
-			<a href="/universe/{post.slug}" class="read-more" tabindex="-1">Continue reading</a>
-		</p>
 	{/if}
 
 	{#if post.attachments && Array.isArray(post.attachments) && post.attachments.length > 0}
@@ -262,9 +262,13 @@
 	.read-more {
 		color: $red-60;
 		text-decoration: none;
-		font-size: 0.875rem;
+		font-size: inherit;
 		font-weight: 500;
 		transition: all 0.2s ease;
+
+		&:hover {
+			text-decoration: underline;
+		}
 	}
 
 	// Hero media pulled from the first image/video node in content

--- a/src/lib/components/UniversePostCard.svelte
+++ b/src/lib/components/UniversePostCard.svelte
@@ -26,10 +26,10 @@
 			: null
 	)
 
-	// Rich excerpt (preserves inline marks incl. links) for essay previews
+	// First paragraph (inline marks/links preserved) for essay previews
 	const essayExcerpt = $derived(
 		post.postType === 'essay' && post.content
-			? renderInlineExcerpt(post.content, 300)
+			? renderInlineExcerpt(post.content)
 			: { html: '', truncated: false }
 	)
 
@@ -216,20 +216,8 @@
 			font-style: italic;
 		}
 
-		&.post-excerpt--essay {
-			display: -webkit-box;
-			-webkit-box-orient: vertical;
-			-webkit-line-clamp: 3;
-			line-clamp: 3;
-			overflow: hidden;
-
-			:global(p) {
-				margin: 0;
-			}
-
-			:global(p + p) {
-				margin-top: $unit;
-			}
+		&.post-excerpt--essay :global(p) {
+			margin: 0;
 		}
 
 		// Hide embeds in the rendered content since we show them separately

--- a/src/lib/components/UniversePostCard.svelte
+++ b/src/lib/components/UniversePostCard.svelte
@@ -81,7 +81,16 @@
 					aria-label={heroMedia.title ?? 'Video preview'}
 				></video>
 				<span class="hero-play" aria-hidden="true">
-					<svg viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z" /></svg>
+					<svg viewBox="0 0 24 24">
+						<path
+							d="M9 6 L19 12 L9 18 Z"
+							fill="currentColor"
+							stroke="currentColor"
+							stroke-width="3"
+							stroke-linejoin="round"
+							stroke-linecap="round"
+						/>
+					</svg>
 				</span>
 			{:else}
 				<img src={heroMedia.src} alt={heroMedia.alt ?? heroMedia.title ?? ''} loading="lazy" />
@@ -279,14 +288,12 @@
 		overflow: hidden;
 		background: $gray-95;
 		border: 1px solid $gray-85;
-		aspect-ratio: 16 / 9;
 
 		img,
 		video {
-			width: 100%;
-			height: 100%;
-			object-fit: cover;
 			display: block;
+			width: 100%;
+			height: auto;
 		}
 	}
 
@@ -308,7 +315,6 @@
 		svg {
 			width: 28px;
 			height: 28px;
-			margin-left: 4px;
 		}
 	}
 

--- a/src/lib/components/UniversePostCard.svelte
+++ b/src/lib/components/UniversePostCard.svelte
@@ -143,7 +143,7 @@
 		>
 			{#if post.postType === 'essay'}
 				<p>
-					{@html essayExcerpt.html}{#if essayExcerpt.truncated}...&nbsp;<a
+					{@html essayExcerpt.html}{#if essayExcerpt.truncated}&nbsp;...&nbsp;<a
 							href="/universe/{post.slug}"
 							class="read-more"
 							tabindex="-1">Continue reading</a

--- a/src/lib/components/UniversePostCard.svelte
+++ b/src/lib/components/UniversePostCard.svelte
@@ -2,7 +2,7 @@
 	import { onMount, onDestroy } from 'svelte'
 	import UniverseCard from './UniverseCard.svelte'
 	import TagPill from './TagPill.svelte'
-	import { getContentExcerpt, renderEdraContent } from '$lib/utils/content'
+	import { renderEdraContent, renderInlineExcerpt } from '$lib/utils/content'
 	import { extractEmbeds } from '$lib/utils/extractEmbeds'
 	import { extractHeroMedia } from '$lib/utils/extractHeroMedia'
 	import { hydrateAudioPlayers } from '$lib/utils/hydrate-audio-players'
@@ -26,15 +26,12 @@
 			: null
 	)
 
-	// Check if content is truncated
-	const isContentTruncated = $derived(() => {
-		if (post.content) {
-			// Check if the excerpt is shorter than the full content
-			const excerpt = getContentExcerpt(post.content)
-			return excerpt.endsWith('...')
-		}
-		return false
-	})
+	// Rich excerpt (preserves inline marks incl. links) for essay previews
+	const essayExcerpt = $derived(
+		post.postType === 'essay' && post.content
+			? renderInlineExcerpt(post.content, 300)
+			: { html: '', truncated: false }
+	)
 
 	let excerptEl: HTMLDivElement | undefined = $state()
 	let cleanupAudio: (() => void) | undefined
@@ -139,9 +136,13 @@
 	{/if}
 
 	{#if post.content}
-		<div class="post-excerpt" bind:this={excerptEl}>
+		<div
+			class="post-excerpt"
+			class:post-excerpt--essay={post.postType === 'essay'}
+			bind:this={excerptEl}
+		>
 			{#if post.postType === 'essay'}
-				<p>{getContentExcerpt(post.content, 300)}</p>
+				{@html essayExcerpt.html}
 			{:else}
 				{@html renderEdraContent(post.content)}
 			{/if}
@@ -156,7 +157,7 @@
 		</div>
 	{/if}
 
-	{#if post.postType === 'essay' && isContentTruncated()}
+	{#if post.postType === 'essay' && essayExcerpt.truncated}
 		<p>
 			<a href="/universe/{post.slug}" class="read-more" tabindex="-1">Continue reading</a>
 		</p>
@@ -185,22 +186,6 @@
 	}
 
 	.post-excerpt {
-		p {
-			margin: 0;
-			color: $gray-10;
-			font-size: 1rem;
-			line-height: 1.5;
-		}
-
-		// Only apply truncation for essay excerpts
-		p:only-child {
-			display: -webkit-box;
-			-webkit-box-orient: vertical;
-			-webkit-line-clamp: 2;
-			line-clamp: 2;
-			overflow: hidden;
-		}
-
 		// Styles for full content (non-essays)
 		:global(p) {
 			margin: 0 0 $unit-2x;
@@ -229,6 +214,22 @@
 
 		:global(em) {
 			font-style: italic;
+		}
+
+		&.post-excerpt--essay {
+			display: -webkit-box;
+			-webkit-box-orient: vertical;
+			-webkit-line-clamp: 3;
+			line-clamp: 3;
+			overflow: hidden;
+
+			:global(p) {
+				margin: 0;
+			}
+
+			:global(p + p) {
+				margin-top: $unit;
+			}
 		}
 
 		// Hide embeds in the rendered content since we show them separately

--- a/src/lib/components/UniversePostCard.svelte
+++ b/src/lib/components/UniversePostCard.svelte
@@ -4,6 +4,7 @@
 	import TagPill from './TagPill.svelte'
 	import { getContentExcerpt, renderEdraContent } from '$lib/utils/content'
 	import { extractEmbeds } from '$lib/utils/extractEmbeds'
+	import { extractHeroMedia } from '$lib/utils/extractHeroMedia'
 	import { hydrateAudioPlayers } from '$lib/utils/hydrate-audio-players'
 	import type { UniverseItem } from '../../routes/api/universe/+server'
 
@@ -16,6 +17,14 @@
 			: []
 	)
 	const firstEmbed = $derived(embeds[0])
+
+	// First image/video node from content, used as hero for essay posts where the
+	// rendered preview is a text-only excerpt and inline media would otherwise be hidden.
+	const heroMedia = $derived(
+		post.postType === 'essay' && !firstEmbed && post.content
+			? extractHeroMedia(post.content as unknown as import('$lib/types/editor').TiptapNode)
+			: null
+	)
 
 	// Check if content is truncated
 	const isContentTruncated = $derived(() => {
@@ -59,6 +68,25 @@
 		<h2 class="card-title">
 			<a href="/universe/{post.slug}" class="card-title-link" tabindex="-1">{post.title}</a>
 		</h2>
+	{/if}
+
+	{#if heroMedia}
+		<a href="/universe/{post.slug}" class="hero-media" tabindex="-1">
+			{#if heroMedia.type === 'video'}
+				<video
+					src={heroMedia.src}
+					muted
+					playsinline
+					preload="metadata"
+					aria-label={heroMedia.title ?? 'Video preview'}
+				></video>
+				<span class="hero-play" aria-hidden="true">
+					<svg viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z" /></svg>
+				</span>
+			{:else}
+				<img src={heroMedia.src} alt={heroMedia.alt ?? heroMedia.title ?? ''} loading="lazy" />
+			{/if}
+		</a>
 	{/if}
 
 	{#if firstEmbed}
@@ -239,6 +267,49 @@
 		font-size: 0.875rem;
 		font-weight: 500;
 		transition: all 0.2s ease;
+	}
+
+	// Hero media pulled from the first image/video node in content
+	.hero-media {
+		position: relative;
+		display: block;
+		width: 100%;
+		margin-bottom: $unit-2x;
+		border-radius: $image-corner-radius;
+		overflow: hidden;
+		background: $gray-95;
+		border: 1px solid $gray-85;
+		aspect-ratio: 16 / 9;
+
+		img,
+		video {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+			display: block;
+		}
+	}
+
+	.hero-play {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+		width: 56px;
+		height: 56px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: white;
+		background: rgba(0, 0, 0, 0.55);
+		border-radius: 50%;
+		pointer-events: none;
+
+		svg {
+			width: 28px;
+			height: 28px;
+			margin-left: 4px;
+		}
 	}
 
 	// Embed preview styles

--- a/src/lib/components/UniversePostCard.svelte
+++ b/src/lib/components/UniversePostCard.svelte
@@ -143,7 +143,7 @@
 		>
 			{#if post.postType === 'essay'}
 				<p>
-					{@html essayExcerpt.html}{#if essayExcerpt.truncated}&nbsp;<a
+					{@html essayExcerpt.html}{#if essayExcerpt.truncated}...&nbsp;<a
 							href="/universe/{post.slug}"
 							class="read-more"
 							tabindex="-1">Continue reading</a

--- a/src/lib/utils/content.ts
+++ b/src/lib/utils/content.ts
@@ -404,6 +404,107 @@ function renderTiptapContent(doc: Record<string, unknown>): string {
 	return (doc.content as ContentNode[]).map(renderNode).join('')
 }
 
+export interface InlineExcerpt {
+	html: string
+	truncated: boolean
+}
+
+// Build an excerpt that preserves inline marks (bold/italic/link/code/etc.)
+// by walking only the top-level paragraphs of a Tiptap doc. Non-paragraph blocks
+// (images, figures, embeds, code blocks) are skipped — hero media handles those.
+export const renderInlineExcerpt = (content: unknown, maxLength = 200): InlineExcerpt => {
+	if (!content) return { html: '', truncated: false }
+
+	const escapeHtml = (str: string): string =>
+		str
+			.replace(/&/g, '&amp;')
+			.replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;')
+			.replace(/"/g, '&quot;')
+			.replace(/'/g, '&#039;')
+
+	const applyMarks = (text: string, marks: Mark[] | undefined): string => {
+		if (!marks) return text
+		let out = text
+		for (const mark of marks) {
+			switch (mark.type) {
+				case 'bold':
+					out = `<strong>${out}</strong>`
+					break
+				case 'italic':
+					out = `<em>${out}</em>`
+					break
+				case 'underline':
+					out = `<u>${out}</u>`
+					break
+				case 'strike':
+					out = `<s>${out}</s>`
+					break
+				case 'code':
+					out = `<code>${out}</code>`
+					break
+				case 'link': {
+					const href = escapeHtml(String(mark.attrs?.href ?? '#'))
+					const target = escapeHtml(String(mark.attrs?.target ?? '_blank'))
+					out = `<a href="${href}" target="${target}" rel="noopener noreferrer">${out}</a>`
+					break
+				}
+				case 'highlight':
+					out = `<mark>${out}</mark>`
+					break
+			}
+		}
+		return out
+	}
+
+	const contentObj = content as Record<string, unknown>
+	if (contentObj.type !== 'doc' || !Array.isArray(contentObj.content)) {
+		// Fallback: plain-text excerpt escaped
+		const text = getContentExcerpt(content, maxLength)
+		return { html: escapeHtml(text), truncated: text.endsWith('...') }
+	}
+
+	const blocks = contentObj.content as ContentNode[]
+	const paragraphs = blocks.filter((b) => b.type === 'paragraph')
+
+	let remaining = maxLength
+	let truncated = false
+	const rendered: string[] = []
+
+	for (let i = 0; i < paragraphs.length; i++) {
+		const para = paragraphs[i]
+		const inline = Array.isArray(para.content) ? para.content : []
+		let paraHtml = ''
+
+		for (const node of inline) {
+			if (remaining <= 0) {
+				truncated = true
+				break
+			}
+			if (node.type !== 'text') continue
+			let text = node.text ?? ''
+			if (text.length > remaining) {
+				text = text.slice(0, remaining).trimEnd() + '...'
+				truncated = true
+			}
+			remaining -= text.length
+			paraHtml += applyMarks(escapeHtml(text), node.marks)
+		}
+
+		if (paraHtml) rendered.push(`<p>${paraHtml}</p>`)
+		if (truncated) break
+	}
+
+	// Flag truncation if we stopped early or the doc had non-paragraph blocks
+	if (!truncated) {
+		if (rendered.length < paragraphs.length || blocks.length > paragraphs.length) {
+			truncated = true
+		}
+	}
+
+	return { html: sanitize(rendered.join('')), truncated }
+}
+
 // Extract text content from Edra JSON for excerpt
 export const getContentExcerpt = (content: EditorData | unknown, maxLength = 200): string => {
 	if (!content) return ''

--- a/src/lib/utils/content.ts
+++ b/src/lib/utils/content.ts
@@ -410,9 +410,10 @@ export interface InlineExcerpt {
 }
 
 // Build an excerpt that renders the first paragraph of a Tiptap doc in full,
-// preserving inline marks (bold/italic/link/code/etc.). Non-paragraph blocks
-// are skipped — hero media handles those. `truncated` is true whenever there is
-// any content beyond that first paragraph so the caller can show a CTA.
+// preserving inline marks (bold/italic/link/code/etc.). The returned `html` is
+// the paragraph's inner HTML (no outer <p>) so callers can splice inline CTAs
+// like "Continue reading" into the same flow. `truncated` is true whenever
+// there's any content beyond that first paragraph.
 export const renderInlineExcerpt = (content: unknown): InlineExcerpt => {
 	if (!content) return { html: '', truncated: false }
 
@@ -490,7 +491,7 @@ export const renderInlineExcerpt = (content: unknown): InlineExcerpt => {
 	// Anything after the chosen paragraph counts as "more" content.
 	const truncated = blocks.length > firstIndex + 1
 
-	return { html: sanitize(`<p>${firstParaHtml}</p>`), truncated }
+	return { html: sanitize(firstParaHtml), truncated }
 }
 
 // Extract text content from Edra JSON for excerpt

--- a/src/lib/utils/content.ts
+++ b/src/lib/utils/content.ts
@@ -409,10 +409,11 @@ export interface InlineExcerpt {
 	truncated: boolean
 }
 
-// Build an excerpt that preserves inline marks (bold/italic/link/code/etc.)
-// by walking only the top-level paragraphs of a Tiptap doc. Non-paragraph blocks
-// (images, figures, embeds, code blocks) are skipped — hero media handles those.
-export const renderInlineExcerpt = (content: unknown, maxLength = 200): InlineExcerpt => {
+// Build an excerpt that renders the first paragraph of a Tiptap doc in full,
+// preserving inline marks (bold/italic/link/code/etc.). Non-paragraph blocks
+// are skipped — hero media handles those. `truncated` is true whenever there is
+// any content beyond that first paragraph so the caller can show a CTA.
+export const renderInlineExcerpt = (content: unknown): InlineExcerpt => {
 	if (!content) return { html: '', truncated: false }
 
 	const escapeHtml = (str: string): string =>
@@ -459,50 +460,37 @@ export const renderInlineExcerpt = (content: unknown, maxLength = 200): InlineEx
 
 	const contentObj = content as Record<string, unknown>
 	if (contentObj.type !== 'doc' || !Array.isArray(contentObj.content)) {
-		// Fallback: plain-text excerpt escaped
-		const text = getContentExcerpt(content, maxLength)
-		return { html: escapeHtml(text), truncated: text.endsWith('...') }
+		const text = getContentExcerpt(content)
+		return { html: escapeHtml(text), truncated: false }
 	}
 
 	const blocks = contentObj.content as ContentNode[]
-	const paragraphs = blocks.filter((b) => b.type === 'paragraph')
 
-	let remaining = maxLength
-	let truncated = false
-	const rendered: string[] = []
-
-	for (let i = 0; i < paragraphs.length; i++) {
-		const para = paragraphs[i]
-		const inline = Array.isArray(para.content) ? para.content : []
+	// Find the first paragraph that actually has some text content.
+	let firstIndex = -1
+	let firstParaHtml = ''
+	for (let i = 0; i < blocks.length; i++) {
+		const block = blocks[i]
+		if (block.type !== 'paragraph') continue
+		const inline = Array.isArray(block.content) ? block.content : []
 		let paraHtml = ''
-
 		for (const node of inline) {
-			if (remaining <= 0) {
-				truncated = true
-				break
-			}
 			if (node.type !== 'text') continue
-			let text = node.text ?? ''
-			if (text.length > remaining) {
-				text = text.slice(0, remaining).trimEnd() + '...'
-				truncated = true
-			}
-			remaining -= text.length
-			paraHtml += applyMarks(escapeHtml(text), node.marks)
+			paraHtml += applyMarks(escapeHtml(node.text ?? ''), node.marks)
 		}
-
-		if (paraHtml) rendered.push(`<p>${paraHtml}</p>`)
-		if (truncated) break
-	}
-
-	// Flag truncation if we stopped early or the doc had non-paragraph blocks
-	if (!truncated) {
-		if (rendered.length < paragraphs.length || blocks.length > paragraphs.length) {
-			truncated = true
+		if (paraHtml.trim()) {
+			firstIndex = i
+			firstParaHtml = paraHtml
+			break
 		}
 	}
 
-	return { html: sanitize(rendered.join('')), truncated }
+	if (firstIndex === -1) return { html: '', truncated: blocks.length > 0 }
+
+	// Anything after the chosen paragraph counts as "more" content.
+	const truncated = blocks.length > firstIndex + 1
+
+	return { html: sanitize(`<p>${firstParaHtml}</p>`), truncated }
 }
 
 // Extract text content from Edra JSON for excerpt

--- a/src/lib/utils/extractHeroMedia.ts
+++ b/src/lib/utils/extractHeroMedia.ts
@@ -1,0 +1,39 @@
+import type { TiptapNode } from '$lib/types/editor'
+
+export interface HeroMedia {
+	type: 'image' | 'video'
+	src: string
+	alt?: string
+	title?: string
+	width?: string | number
+	height?: string | number
+}
+
+const MEDIA_TYPES = new Set(['image', 'video'])
+
+export function extractHeroMedia(content: TiptapNode | null | undefined): HeroMedia | null {
+	if (!content || !content.content) return null
+
+	const stack: TiptapNode[] = [...(content.content as TiptapNode[])]
+
+	while (stack.length) {
+		const node = stack.shift()!
+
+		if (MEDIA_TYPES.has(node.type) && node.attrs && typeof node.attrs.src === 'string') {
+			return {
+				type: node.type as 'image' | 'video',
+				src: node.attrs.src as string,
+				alt: typeof node.attrs.alt === 'string' ? (node.attrs.alt as string) : undefined,
+				title: typeof node.attrs.title === 'string' ? (node.attrs.title as string) : undefined,
+				width: node.attrs.width as string | number | undefined,
+				height: node.attrs.height as string | number | undefined
+			}
+		}
+
+		if (node.content && Array.isArray(node.content)) {
+			stack.unshift(...(node.content as TiptapNode[]))
+		}
+	}
+
+	return null
+}

--- a/src/routes/api/universe/+server.ts
+++ b/src/routes/api/universe/+server.ts
@@ -1,5 +1,5 @@
 import type { RequestHandler } from './$types'
-import type { Prisma } from '@prisma/client'
+import { Prisma } from '@prisma/client'
 import { prisma } from '$lib/server/database'
 import { jsonResponse, errorResponse } from '$lib/server/api-utils'
 import { logger } from '$lib/server/logger'
@@ -23,7 +23,7 @@ interface Tag {
 
 export interface UniverseItem {
 	id: number
-	type: 'post' | 'album'
+	type: 'post' | 'album' | 'garden'
 	slug: string
 	title?: string
 	content?: Prisma.JsonValue
@@ -44,6 +44,15 @@ export interface UniverseItem {
 	coverPhoto?: AlbumPhoto
 	photos?: AlbumPhoto[]
 	hasContent?: boolean
+
+	// Garden-specific fields
+	category?: string
+	creator?: string
+	imageUrl?: string
+	summary?: string
+	rating?: number
+	isFavorite?: boolean
+	isCurrent?: boolean
 }
 
 // GET /api/universe - Get mixed feed of published posts and albums
@@ -83,6 +92,16 @@ export const GET: RequestHandler = async (event) => {
 				}
 			},
 			orderBy: { publishedAt: 'desc' }
+		})
+
+		// Fetch published garden items opted into the Universe feed
+		const gardenItems = await prisma.gardenItem.findMany({
+			where: {
+				status: 'published',
+				showInUniverse: true,
+				note: { not: Prisma.DbNull }
+			},
+			orderBy: [{ publishedAt: 'desc' }, { createdAt: 'desc' }]
 		})
 
 		// Fetch published albums marked for Universe
@@ -167,8 +186,29 @@ export const GET: RequestHandler = async (event) => {
 			}
 		})
 
+		// Transform garden items to universe items
+		const gardenUniverseItems: UniverseItem[] = gardenItems.map((item) => {
+			const pubDate = item.publishedAt ?? item.createdAt
+			return {
+				id: item.id,
+				type: 'garden' as const,
+				slug: item.slug,
+				title: item.title,
+				content: item.note,
+				category: item.category,
+				creator: item.creator || undefined,
+				imageUrl: item.imageUrl || undefined,
+				summary: item.summary || undefined,
+				rating: item.rating ?? undefined,
+				isFavorite: item.isFavorite,
+				isCurrent: item.isCurrent,
+				publishedAt: pubDate.toISOString(),
+				createdAt: item.createdAt.toISOString()
+			}
+		})
+
 		// Combine and sort by publishedAt
-		const allItems = [...postItems, ...albumItems].sort(
+		const allItems = [...postItems, ...albumItems, ...gardenUniverseItems].sort(
 			(a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime()
 		)
 


### PR DESCRIPTION
## Summary

- Garden items with `showInUniverse: true` + a `note` now appear on the `/universe` page, not just in the RSS feed. New `UniverseGardenCard` (category eyebrow, cover image, creator, excerpt) rendered alongside posts and albums, sorted by `publishedAt` desc.
- Essay-type posts now extract the first image or video node from their body and show it as a hero above the text excerpt. Videos render as a silent `<video preload=metadata>` (no controls) with a play-icon overlay — reads as a still but signals playability. Previously a video buried in an essay never surfaced on the list page.
- `UniverseCard` gained a `'garden'` type and an optional `href` override so Garden items link to `/garden/{category}/{slug}`.

Scope: only essays get hero-hoisting. Non-essay post types (notes, threads) already render their full content inline in the preview, so media is already visible.

## Test plan

- [ ] `/universe` — Garden item opted into Universe shows up as a card with cover image, category eyebrow, creator, excerpt; clicking goes to `/garden/{category}/{slug}`
- [ ] `/universe` — Garden item *not* opted in (`showInUniverse: false`) does not appear
- [ ] `/universe` — Garden item with null `note` does not appear (prevents bare catalog entries)
- [ ] Sort order: Garden items interleave correctly with Posts/Albums by `publishedAt`
- [ ] Essay with a video in the body — video surfaces as a hero with a play overlay; clicking the hero goes to `/universe/{slug}`
- [ ] Essay with an image in the body (no video) — image surfaces as hero
- [ ] Essay with a URL embed takes precedence — embed shows, hero does not (avoids double media)
- [ ] Non-essay post (note/thread) with inline media — behaves identically to before (no extra hero)