### PR TITLE
save without reload across project, garden, and album forms

### DIFF
--- a/src/lib/components/admin/AlbumForm.svelte
+++ b/src/lib/components/admin/AlbumForm.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { goto } from '$app/navigation'
+	import { goto, replaceState } from '$app/navigation'
 	import { z } from 'zod'
 	import AdminPage from './AdminPage.svelte'
 	import AdminSegmentedControl from './AdminSegmentedControl.svelte'
@@ -19,7 +19,11 @@
 		mode: 'create' | 'edit'
 	}
 
-	let { album = null, mode }: Props = $props()
+	let { album: initialAlbum = null, mode: initialMode }: Props = $props()
+
+	// Local state so we can transition create → edit in place after first save.
+	let album = $state(initialAlbum)
+	let mode = $state<'create' | 'edit'>(initialMode)
 
 	// Album schema for validation
 	const albumSchema = z.object({
@@ -244,12 +248,11 @@
 				toast.success(`Album ${mode === 'edit' ? 'saved' : 'created'} successfully!`)
 			}
 
+			album = savedAlbum
+			populateFormData(savedAlbum)
 			if (mode === 'create') {
-				goto(`/admin/albums/${savedAlbum.id}/edit`)
-			} else if (mode === 'edit' && album) {
-				// Update the album object to reflect saved changes
-				album = savedAlbum
-				populateFormData(savedAlbum)
+				mode = 'edit'
+				replaceState(`/admin/albums/${savedAlbum.id}/edit`, {})
 			}
 		} catch (err) {
 			toast.dismiss(loadingToastId)

--- a/src/lib/components/admin/AlbumForm.svelte
+++ b/src/lib/components/admin/AlbumForm.svelte
@@ -248,11 +248,14 @@
 				toast.success(`Album ${mode === 'edit' ? 'saved' : 'created'} successfully!`)
 			}
 
+			const wasCreate = mode === 'create'
 			album = savedAlbum
 			populateFormData(savedAlbum)
-			if (mode === 'create') {
+			if (wasCreate) {
 				mode = 'edit'
+				pendingMediaIds = []
 				replaceState(`/admin/albums/${savedAlbum.id}/edit`, {})
+				await loadAlbumMedia()
 			}
 		} catch (err) {
 			toast.dismiss(loadingToastId)

--- a/src/lib/components/admin/BaseDropdown.svelte
+++ b/src/lib/components/admin/BaseDropdown.svelte
@@ -11,8 +11,10 @@
 		dropdownTriggerSize?: 'small' | 'medium' | 'large'
 		class?: string
 		onToggle?: (isOpen: boolean) => void
-		trigger: Snippet
+		trigger: Snippet<[(e: MouseEvent) => void]>
 		dropdown?: Snippet
+		// When true, suppress the auto chevron button — the caller's trigger snippet is the only thing that opens the menu.
+		combined?: boolean
 	}
 
 	let {
@@ -23,7 +25,8 @@
 		class: className = '',
 		onToggle,
 		trigger,
-		dropdown
+		dropdown,
+		combined = false
 	}: Props = $props()
 
 	function handleDropdownToggle(e: MouseEvent) {
@@ -44,9 +47,9 @@
 	onclickoutside={handleClickOutside}
 >
 	<div class="dropdown-trigger">
-		{@render trigger()}
+		{@render trigger(handleDropdownToggle)}
 
-		{#if dropdown}
+		{#if dropdown && !combined}
 			<Button
 				variant="ghost"
 				iconOnly

--- a/src/lib/components/admin/Button.svelte
+++ b/src/lib/components/admin/Button.svelte
@@ -168,7 +168,6 @@
 {/if}
 
 <style lang="scss">
-
 	// Base button styles
 	.btn {
 		display: inline-flex;
@@ -303,15 +302,15 @@
 	}
 
 	.btn-danger {
-		background-color: $yellow-60;
-		color: $yellow-10;
+		background-color: $red-60;
+		color: $white;
 
 		&:hover:not(:disabled) {
-			background-color: $yellow-50;
+			background-color: $red-50;
 		}
 
 		&:active:not(:disabled) {
-			background-color: $yellow-40;
+			background-color: $red-40;
 		}
 	}
 

--- a/src/lib/components/admin/GardenItemForm.svelte
+++ b/src/lib/components/admin/GardenItemForm.svelte
@@ -317,6 +317,7 @@
 			slug = savedItem.slug
 			sourceId = savedItem.sourceId ?? ''
 			metadata = (savedItem.metadata as Record<string, unknown>) ?? null
+			autoSlug = false
 			if (mode === 'create') {
 				mode = 'edit'
 				replaceState(`/admin/garden/${savedItem.id}/edit`, {})

--- a/src/lib/components/admin/GardenItemForm.svelte
+++ b/src/lib/components/admin/GardenItemForm.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { goto, beforeNavigate } from '$app/navigation'
+	import { goto, beforeNavigate, replaceState } from '$app/navigation'
 	import type { BeforeNavigate } from '@sveltejs/kit'
 	import { api } from '$lib/admin/api'
 	import AdminPage from './AdminPage.svelte'
@@ -31,7 +31,11 @@
 		mode: 'create' | 'edit'
 	}
 
-	let { item = null, mode }: Props = $props()
+	let { item: initialItem = null, mode: initialMode }: Props = $props()
+
+	// Local state so we can transition create → edit in place after first save.
+	let item = $state(initialItem)
+	let mode = $state<'create' | 'edit'>(initialMode)
 
 	// Form state
 	let category = $state<GardenCategory>((item?.category as GardenCategory) ?? 'books')
@@ -307,16 +311,15 @@
 				note: JSON.stringify(savedItem.note ?? { type: 'doc', content: [{ type: 'paragraph' }] })
 			}
 
+			item = savedItem
+			// Sync local state with saved data
+			status = savedItem.status as 'draft' | 'published'
+			slug = savedItem.slug
+			sourceId = savedItem.sourceId ?? ''
+			metadata = (savedItem.metadata as Record<string, unknown>) ?? null
 			if (mode === 'create') {
-				isSavedNavigation = true
-				goto(`/admin/garden/${savedItem.id}/edit`)
-			} else {
-				item = savedItem
-				// Sync local state with saved data
-				status = savedItem.status as 'draft' | 'published'
-				slug = savedItem.slug
-				sourceId = savedItem.sourceId ?? ''
-				metadata = (savedItem.metadata as Record<string, unknown>) ?? null
+				mode = 'edit'
+				replaceState(`/admin/garden/${savedItem.id}/edit`, {})
 			}
 		} catch (err) {
 			toast.dismiss(loadingToastId)

--- a/src/lib/components/admin/PostMetadataForm.svelte
+++ b/src/lib/components/admin/PostMetadataForm.svelte
@@ -22,6 +22,7 @@
 		createdAt: string | Date
 		updatedAt: string | Date
 		publishedAt: string | Date | null
+		onSlugEdit?: () => void
 	}
 
 	let {
@@ -33,7 +34,8 @@
 		heartCount,
 		createdAt,
 		updatedAt,
-		publishedAt
+		publishedAt,
+		onSlugEdit
 	}: PostMetadataFormProps = $props()
 
 	// Featured image media state for ImagePicker
@@ -104,6 +106,7 @@
 		label="Slug"
 		size="jumbo"
 		bind:value={slug}
+		oninput={() => onSlugEdit?.()}
 		placeholder="post-slug"
 		helpText="URL-friendly identifier for this post"
 	/>

--- a/src/lib/components/admin/ProjectForm.svelte
+++ b/src/lib/components/admin/ProjectForm.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { goto, beforeNavigate } from '$app/navigation'
+	import { goto, beforeNavigate, replaceState } from '$app/navigation'
 	import { api } from '$lib/admin/api'
 	import AdminPage from './AdminPage.svelte'
 	import AdminSegmentedControl from './AdminSegmentedControl.svelte'
@@ -17,7 +17,11 @@
 		mode: 'create' | 'edit'
 	}
 
-	let { project = null, mode }: Props = $props()
+	let { project: initialProject = null, mode: initialMode }: Props = $props()
+
+	// Local state so we can transition create → edit in place after first save.
+	let project = $state(initialProject)
+	let mode = $state<'create' | 'edit'>(initialMode)
 
 	// Form store - centralized state management
 	const formStore = createProjectFormStore(project)
@@ -138,11 +142,11 @@
 			toast.dismiss(loadingToastId)
 			toast.success(`Project ${mode === 'edit' ? 'saved' : 'created'} successfully!`)
 
+			project = savedProject
+			formStore.populateFromProject(savedProject)
 			if (mode === 'create') {
-				goto(`/admin/projects/${savedProject.id}/edit`)
-			} else {
-				project = savedProject
-				formStore.populateFromProject(savedProject)
+				mode = 'edit'
+				replaceState(`/admin/projects/${savedProject.id}/edit`, {})
 			}
 		} catch (err) {
 			toast.dismiss(loadingToastId)

--- a/src/lib/components/admin/StatusDropdown.svelte
+++ b/src/lib/components/admin/StatusDropdown.svelte
@@ -18,6 +18,9 @@
 		viewUrl?: string
 		onDelete?: () => void
 		onCopyPreviewLink?: () => void
+		// When provided, the trigger renders as a single text + chevron button (no separate primary action button).
+		// Used for the auto-save flow where the status text replaces the manual save button.
+		triggerText?: string
 	}
 
 	let {
@@ -29,7 +32,8 @@
 		altActions,
 		viewUrl,
 		onDelete,
-		onCopyPreviewLink
+		onCopyPreviewLink,
+		triggerText
 	}: Props = $props()
 
 	let isDropdownOpen = $state(false)
@@ -67,18 +71,51 @@
 	}
 </script>
 
-<BaseDropdown bind:isOpen={isDropdownOpen} {disabled} {isLoading} class="status-dropdown">
-	{#snippet trigger()}
-		<Button
-			variant="primary"
-			buttonSize="medium"
-			onclick={handlePrimary}
-			disabled={disabled || isLoading}
-		>
-			{#snippet children()}
-				{resolvedPrimaryLabel}
-			{/snippet}
-		</Button>
+<BaseDropdown
+	bind:isOpen={isDropdownOpen}
+	{disabled}
+	{isLoading}
+	class="status-dropdown"
+	combined={triggerText !== undefined}
+>
+	{#snippet trigger(toggle)}
+		{#if triggerText !== undefined}
+			<button
+				type="button"
+				class="combined-trigger"
+				onclick={toggle}
+				disabled={disabled || isLoading}
+			>
+				<span class="combined-trigger__label">{triggerText}</span>
+				<svg
+					class="combined-trigger__chevron"
+					width="12"
+					height="12"
+					viewBox="0 0 12 12"
+					fill="none"
+					aria-hidden="true"
+				>
+					<path
+						d="M3 4.5L6 7.5L9 4.5"
+						stroke="currentColor"
+						stroke-width="1.5"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+					/>
+				</svg>
+			</button>
+		{:else}
+			<Button
+				variant="primary"
+				buttonSize="medium"
+				onclick={handlePrimary}
+				disabled={disabled || isLoading}
+			>
+				{#snippet children()}
+					{resolvedPrimaryLabel}
+				{/snippet}
+			</Button>
+		{/if}
 	{/snippet}
 
 	{#snippet dropdown()}
@@ -124,6 +161,41 @@
 </BaseDropdown>
 
 <style lang="scss">
+	.combined-trigger {
+		display: inline-flex;
+		align-items: center;
+		gap: $unit-half;
+		padding: $unit $unit-2x;
+		background: $gray-95;
+		border: 1px solid $gray-90;
+		border-radius: 50px;
+		font-size: 0.875rem;
+		color: $gray-20;
+		cursor: pointer;
+		transition:
+			background-color $transition-normal ease,
+			border-color $transition-normal ease;
+
+		&:hover:not(:disabled) {
+			background: $gray-90;
+			border-color: $gray-85;
+		}
+
+		&:disabled {
+			opacity: 0.6;
+			cursor: not-allowed;
+		}
+	}
+
+	.combined-trigger__label {
+		white-space: nowrap;
+	}
+
+	.combined-trigger__chevron {
+		flex-shrink: 0;
+		opacity: 0.6;
+	}
+
 	.dropdown-divider {
 		height: 1px;
 		background-color: $gray-80;

--- a/src/lib/components/admin/forms/PostForm.svelte
+++ b/src/lib/components/admin/forms/PostForm.svelte
@@ -12,6 +12,7 @@
 	import StatusDropdown from '$lib/components/admin/StatusDropdown.svelte'
 	import type { JSONContent } from '@tiptap/core'
 	import type { ApiPost, PostFormTag as Tag } from './post-types'
+	import { useAutoSave } from './useAutoSave.svelte'
 
 	// Legacy blocks format (pre-Tiptap) — still in some old posts.
 	interface BlockContent {
@@ -66,7 +67,31 @@
 	let showUnsavedChangesModal = $state(false)
 	let pendingNavigationUrl = $state<string | null>(null)
 	let allowNavigation = $state(false)
-	let savedSnapshot = $state<string | null>(initialPost ? snapshot() : null)
+
+	// Snapshot-based dirty tracking. The $derived only recomputes when one of the read fields changes,
+	// and crucially does NOT write any reactive state — so it can't form a feedback loop with the
+	// auto-save effect that reads isDirty.
+	function snapshot() {
+		return JSON.stringify([
+			title,
+			postType,
+			status,
+			slug,
+			excerpt,
+			syndicationText,
+			featuredImage,
+			syndicateBluesky,
+			syndicateMastodon,
+			appendLink,
+			content,
+			tags
+				.map((t) => t.id)
+				.sort()
+				.join(',')
+		])
+	}
+
+	let savedSnapshot = $state<string>(snapshot())
 
 	const postTypeConfig = {
 		post: { icon: '💭', label: 'Post', showTitle: false, showContent: true },
@@ -87,37 +112,32 @@
 				]
 	)
 
-	function snapshot() {
-		return JSON.stringify({
-			title,
-			postType,
-			status,
-			slug,
-			excerpt,
-			syndicationText,
-			featuredImage,
-			syndicateBluesky,
-			syndicateMastodon,
-			appendLink,
-			content,
-			tagIds: tags
-				.map((t) => t.id)
-				.sort()
-				.join(',')
-		})
-	}
+	let isDirty = $derived(snapshot() !== savedSnapshot)
 
-	// Pre-first-save: dirty if the form has any content. After save: dirty if state diverges from the saved snapshot.
-	let isDirty = $derived(
-		savedSnapshot === null
-			? title.trim() !== '' ||
-					slug.trim() !== '' ||
-					excerpt.trim() !== '' ||
-					syndicationText.trim() !== '' ||
-					tags.length > 0 ||
-					(content.content && content.content.length > 0)
-			: snapshot() !== savedSnapshot
-	)
+	// Auto-save runs only for drafts (publishing has explicit syndication side effects we shouldn't trigger silently).
+	// Pre-first-save it requires a real change so a blank /admin/posts/new doesn't post an empty post on mount.
+	const autoSave = useAutoSave({
+		enabled: () => status === 'draft',
+		isDirty: () => isDirty,
+		save: () => handleSave(status)
+	})
+
+	const autoSaveLabel = $derived.by(() => {
+		switch (autoSave.state) {
+			case 'saving':
+				return 'Saving…'
+			case 'unsaved':
+				return 'Unsaved'
+			case 'failed':
+				return 'Save failed'
+			case 'conflict':
+				return 'Conflict — reload'
+			case 'saved':
+			case 'idle':
+			default:
+				return 'Saved'
+		}
+	})
 
 	// Auto-generate slug from title for new posts.
 	$effect(() => {
@@ -130,16 +150,29 @@
 		}
 	})
 
-	// Cmd+S keyboard shortcut.
+	// Cmd+S keyboard shortcut. For drafts: flush the auto-save debounce. For published: trigger save directly.
 	$effect(() => {
 		function handleKeydown(e: KeyboardEvent) {
 			if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 's') {
 				e.preventDefault()
-				handleSave(status)
+				if (status === 'draft') {
+					void autoSave.flush()
+				} else {
+					handleSave(status)
+				}
 			}
 		}
 		document.addEventListener('keydown', handleKeydown)
 		return () => document.removeEventListener('keydown', handleKeydown)
+	})
+
+	// Flush pending auto-save when the window loses focus (matches Notion's behavior).
+	$effect(() => {
+		function handleBlur() {
+			if (status === 'draft') void autoSave.flush()
+		}
+		window.addEventListener('blur', handleBlur)
+		return () => window.removeEventListener('blur', handleBlur)
 	})
 
 	// Browser warning for page unloads (refresh/close).
@@ -159,11 +192,32 @@
 			allowNavigation = false
 			return
 		}
-		if (isDirty && navigation.type !== 'leave' && navigation.to) {
-			pendingNavigationUrl = navigation.to.url.pathname
+		if (!isDirty || navigation.type === 'leave' || !navigation.to) return
+
+		const targetUrl = navigation.to.url.pathname
+
+		// Drafts: try to flush auto-save silently, then continue. If the flush fails
+		// (network, 409, etc), fall back to the unsaved-changes modal so we never drop edits silently.
+		if (status === 'draft' && autoSave.state !== 'conflict') {
 			navigation.cancel()
-			showUnsavedChangesModal = true
+			autoSave.flush().then(
+				() => {
+					allowNavigation = true
+					goto(targetUrl)
+				},
+				() => {
+					// Save failed — keep the user on the page and surface the modal.
+					pendingNavigationUrl = targetUrl
+					showUnsavedChangesModal = true
+				}
+			)
+			return
 		}
+
+		// Published / conflict: keep the existing unsaved-changes prompt.
+		pendingNavigationUrl = targetUrl
+		navigation.cancel()
+		showUnsavedChangesModal = true
 	})
 
 	function normalizeContent(raw: unknown): JSONContent {
@@ -303,6 +357,13 @@
 		const targetStatus = (target as 'draft' | 'published') || status
 		saving = true
 
+		// Apply the status transition first so the submitting snapshot reflects what we're about to send.
+		status = targetStatus
+
+		// Capture the snapshot BEFORE the await. Mid-save keystrokes won't be reflected in this string —
+		// they'll show as dirty after the save completes, and the next debounce picks them up.
+		const submittingSnapshot = snapshot()
+
 		const postData = {
 			title: config?.showTitle ? title : null,
 			slug: slug || `post-${Date.now()}`,
@@ -323,7 +384,8 @@
 				const created = await api.post<ApiPost>('/api/posts', postData)
 				id = created.id
 				updatedAt = created.updatedAt
-				slug = created.slug
+				// Adopt the server-canonicalized slug (we may have submitted a generated `post-${Date.now()}`).
+				if (slug !== created.slug) slug = created.slug
 				slugManuallySet = true
 				replaceState(`/admin/posts/${created.id}/edit`, {})
 			} else {
@@ -333,14 +395,17 @@
 				})
 				if (saved) {
 					updatedAt = saved.updatedAt
-					slug = saved.slug
+					// Don't sync slug back — server doesn't mutate slug, and syncing would clobber
+					// a slug edit the user may have made during the in-flight save.
 					slugManuallySet = true
 				}
 			}
-			status = targetStatus
-			savedSnapshot = snapshot()
+			// Mark the version we actually submitted as saved. Mid-await keystrokes diverge from this
+			// snapshot, so isDirty stays true and the next debounce flushes them.
+			savedSnapshot = submittingSnapshot
 		} catch (error) {
 			console.error('Failed to save post:', error)
+			throw error
 		} finally {
 			saving = false
 		}
@@ -416,9 +481,17 @@
 			<div class="header-actions">
 				<StatusDropdown
 					{status}
-					onSave={handleSave}
+					onSave={(target) => {
+						// If the user is publishing a dirty draft, flush any pending auto-save first so we publish on top of the latest saved snapshot.
+						if (status === 'draft' && target !== 'draft' && isDirty) {
+							void autoSave.flush().then(() => handleSave(target))
+						} else {
+							handleSave(target)
+						}
+					}}
 					disabled={saving}
 					isLoading={saving}
+					triggerText={status === 'draft' ? autoSaveLabel : undefined}
 					viewUrl={status === 'published' && slug ? `/universe/${slug}` : undefined}
 					onDelete={id !== null ? openDeleteConfirmation : undefined}
 					onCopyPreviewLink={id !== null && slug ? handleCopyPreviewLink : undefined}
@@ -457,6 +530,7 @@
 					createdAt={initialPost?.createdAt ?? new Date().toISOString()}
 					updatedAt={initialPost?.updatedAt ?? new Date().toISOString()}
 					publishedAt={initialPost?.publishedAt ?? null}
+					onSlugEdit={() => (slugManuallySet = true)}
 				/>
 			</div>
 

--- a/src/lib/components/admin/forms/useAutoSave.svelte.ts
+++ b/src/lib/components/admin/forms/useAutoSave.svelte.ts
@@ -1,0 +1,148 @@
+// Notion/Coda-style draft auto-save: debounced, single-in-flight, with a small status state machine.
+// Intentionally minimal — no localStorage fallback, no draft recovery, no offline retry queue.
+//
+// Design note: the visible state ('idle' | 'unsaved' | …) is a $derived computed from a few
+// primitive flags. The debounce $effect only writes non-reactive timer handles, never the state
+// it also reads — that combination is what produces feedback loops with caller-side trackers.
+
+export type AutoSaveState = 'idle' | 'unsaved' | 'saving' | 'saved' | 'failed' | 'conflict'
+
+export interface AutoSaveOptions {
+	enabled: () => boolean
+	isDirty: () => boolean
+	save: () => Promise<void>
+	debounceMs?: number
+	savedVisibleMs?: number
+}
+
+export interface AutoSave {
+	readonly state: AutoSaveState
+	flush(): Promise<void>
+}
+
+const DEFAULT_DEBOUNCE_MS = 1500
+const DEFAULT_SAVED_VISIBLE_MS = 2000
+
+export function useAutoSave(opts: AutoSaveOptions): AutoSave {
+	const debounceMs = opts.debounceMs ?? DEFAULT_DEBOUNCE_MS
+	const savedVisibleMs = opts.savedVisibleMs ?? DEFAULT_SAVED_VISIBLE_MS
+
+	let isSaving = $state(false)
+	let savedFlash = $state(false)
+	let saveError = $state<'failed' | 'conflict' | null>(null)
+
+	let timer: ReturnType<typeof setTimeout> | null = null
+	let savedTimer: ReturnType<typeof setTimeout> | null = null
+	let inflight: Promise<void> | null = null
+	let pending = false
+
+	const state: AutoSaveState = $derived.by(() => {
+		if (saveError === 'conflict') return 'conflict'
+		if (saveError === 'failed') return 'failed'
+		if (isSaving) return 'saving'
+		if (savedFlash) return 'saved'
+		if (opts.enabled() && opts.isDirty()) return 'unsaved'
+		return 'idle'
+	})
+
+	function clearTimer() {
+		if (timer !== null) {
+			clearTimeout(timer)
+			timer = null
+		}
+	}
+
+	function clearSavedTimer() {
+		if (savedTimer !== null) {
+			clearTimeout(savedTimer)
+			savedTimer = null
+		}
+	}
+
+	async function runSave(): Promise<void> {
+		clearTimer()
+		clearSavedTimer()
+		if (!opts.enabled() || saveError === 'conflict') return
+		isSaving = true
+		savedFlash = false
+		try {
+			await opts.save()
+			isSaving = false
+			savedFlash = true
+			savedTimer = setTimeout(() => {
+				savedFlash = false
+				savedTimer = null
+			}, savedVisibleMs)
+		} catch (err) {
+			isSaving = false
+			const status = (err as { status?: number } | null)?.status
+			saveError = status === 409 ? 'conflict' : 'failed'
+			throw err
+		}
+	}
+
+	async function performSave(): Promise<void> {
+		if (inflight) {
+			pending = true
+			try {
+				await inflight
+			} catch {
+				// swallow — original caller already saw it
+			}
+			if (!pending) return
+			pending = false
+			if (!opts.isDirty() || !opts.enabled() || saveError === 'conflict') return
+			return performSave()
+		}
+		inflight = (async () => {
+			try {
+				await runSave()
+			} finally {
+				inflight = null
+			}
+		})()
+		try {
+			await inflight
+		} finally {
+			if (pending && opts.isDirty() && opts.enabled() && saveError !== 'conflict') {
+				pending = false
+				await performSave()
+			} else {
+				pending = false
+			}
+		}
+	}
+
+	// Debounce timer driver. Only reads enabled/isDirty/saveError; never writes state-related $state
+	// inside this effect — those writes happen from runSave (an async call out of band).
+	$effect(() => {
+		if (!opts.enabled() || saveError === 'conflict') {
+			clearTimer()
+			return
+		}
+		if (!opts.isDirty()) {
+			clearTimer()
+			return
+		}
+		clearTimer()
+		timer = setTimeout(() => {
+			timer = null
+			if (!opts.enabled() || !opts.isDirty() || saveError === 'conflict') return
+			void performSave()
+		}, debounceMs)
+	})
+
+	async function flush(): Promise<void> {
+		clearTimer()
+		if (!opts.enabled() || saveError === 'conflict') return
+		if (!opts.isDirty() && !inflight) return
+		await performSave()
+	}
+
+	return {
+		get state() {
+			return state
+		},
+		flush
+	}
+}


### PR DESCRIPTION
Stacked on #88.

## Summary
- ProjectForm, GardenItemForm, and AlbumForm now use `replaceState` instead of `goto` after first save in create mode
- each form keeps the loaded record locally and transitions `mode` from `'create'` to `'edit'` in place — no remount, scroll/focus preserved
- the existing post-save state-sync paths (`project = savedProject`, `populateFromProject`, `populateFormData`, `item = savedItem`, `status = savedItem.status`, etc.) now run for both branches; the only difference between create and edit branches is the URL swap
- `mode` and the loaded record (`project` / `item` / `album`) are now shadowed as local `$state` so we can mutate them after save without fighting the prop reactivity

This is PR 3 of the planned admin save-flow refactor. After this, the create→edit transition is consistent and reload-free across all four content types (posts, projects, garden, albums).

## Test plan
- [ ] `/admin/projects/new`: fill in metadata → save → URL silently swaps to `/admin/projects/[id]/edit`. Form stays mounted; subsequent saves go to PUT.
- [ ] `/admin/garden/new`: same.
- [ ] `/admin/albums/new`: same. If `pendingMediaIds` exist, they still post to `/api/albums/[id]/media` after first save.
- [ ] edit pages for all three: existing save flow unchanged.
- [ ] unsaved-changes guard: trying to navigate away with a dirty draft still shows the modal.
- [ ] `pnpm run check` net error count unchanged at 118.