### PR TITLE
advertise publish time, not create time, for published drafts

### DIFF
--- a/prisma/migrations/20260501000000_backfill_album_published_at/migration.sql
+++ b/prisma/migrations/20260501000000_backfill_album_published_at/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "Album" ADD COLUMN IF NOT EXISTS "publishedAt" TIMESTAMP(3);
+
+UPDATE "Album"
+SET "publishedAt" = "createdAt"
+WHERE status = 'published' AND "publishedAt" IS NULL;

--- a/src/routes/api/albums/[id]/+server.ts
+++ b/src/routes/api/albums/[id]/+server.ts
@@ -118,6 +118,14 @@ export const PUT: RequestHandler = async (event) => {
 			}
 		}
 
+		const nextStatus = body.status !== undefined ? body.status : existing.status
+		let publishedAt: Date | null = existing.publishedAt
+		if (nextStatus === 'published' && existing.status !== 'published') {
+			publishedAt = new Date()
+		} else if (nextStatus === 'draft' && existing.status === 'published') {
+			publishedAt = null
+		}
+
 		// Update album
 		const album = await prisma.album.update({
 			where: { id },
@@ -128,7 +136,8 @@ export const PUT: RequestHandler = async (event) => {
 				date: body.date !== undefined ? (body.date ? new Date(body.date) : null) : existing.date,
 				location: body.location !== undefined ? body.location : existing.location,
 				coverPhotoId: body.coverPhotoId !== undefined ? body.coverPhotoId : existing.coverPhotoId,
-				status: body.status !== undefined ? body.status : existing.status,
+				status: nextStatus,
+				publishedAt,
 				showInUniverse:
 					body.showInUniverse !== undefined ? body.showInUniverse : existing.showInUniverse,
 				content:

--- a/src/routes/api/posts/[id]/+server.ts
+++ b/src/routes/api/posts/[id]/+server.ts
@@ -79,8 +79,10 @@ export const PUT: RequestHandler = async (event) => {
 			}
 		}
 
-		if (data.status === 'published' && existing.status !== 'published' && !existing.publishedAt) {
+		if (data.status === 'published' && existing.status !== 'published') {
 			data.publishedAt = new Date()
+		} else if (data.status === 'draft' && existing.status === 'published') {
+			data.publishedAt = null
 		}
 
 		const featuredImageId = data.featuredImage
@@ -204,9 +206,9 @@ export const PATCH: RequestHandler = async (event) => {
 
 		if (data.status !== undefined) {
 			updateData.status = data.status
-			if (data.status === 'published' && !existing.publishedAt) {
+			if (data.status === 'published' && existing.status !== 'published') {
 				updateData.publishedAt = new Date()
-			} else if (data.status === 'draft') {
+			} else if (data.status === 'draft' && existing.status === 'published') {
 				updateData.publishedAt = null
 			}
 		}
@@ -222,7 +224,6 @@ export const PATCH: RequestHandler = async (event) => {
 			updateData.attachments =
 				data.attachedPhotos && data.attachedPhotos.length > 0 ? data.attachedPhotos : null
 		if (data.tags !== undefined) updateData.tags = data.tags
-		if (data.publishedAt !== undefined) updateData.publishedAt = data.publishedAt
 		if (data.excerpt !== undefined) updateData.excerpt = data.excerpt
 		if (data.syndicationText !== undefined) updateData.syndicationText = data.syndicationText
 		if (data.syndicateBluesky !== undefined) updateData.syndicateBluesky = data.syndicateBluesky

--- a/src/routes/api/universe/+server.ts
+++ b/src/routes/api/universe/+server.ts
@@ -118,6 +118,7 @@ export const GET: RequestHandler = async (event) => {
 				date: true,
 				location: true,
 				content: true,
+				publishedAt: true,
 				createdAt: true,
 				_count: {
 					select: { media: true }
@@ -139,7 +140,7 @@ export const GET: RequestHandler = async (event) => {
 					}
 				}
 			},
-			orderBy: { createdAt: 'desc' }
+			orderBy: [{ publishedAt: 'desc' }, { createdAt: 'desc' }]
 		})
 
 		// Transform posts to universe items
@@ -181,7 +182,7 @@ export const GET: RequestHandler = async (event) => {
 				coverPhoto: photos[0] || null, // Keep for backward compatibility
 				photos: photos, // Add all photos for slideshow
 				hasContent: !!album.content, // Add content indicator
-				publishedAt: album.createdAt.toISOString(), // Albums use createdAt as publishedAt
+				publishedAt: (album.publishedAt ?? album.createdAt).toISOString(),
 				createdAt: album.createdAt.toISOString()
 			}
 		})

--- a/src/routes/rss/+server.ts
+++ b/src/routes/rss/+server.ts
@@ -32,7 +32,7 @@ export const GET: RequestHandler = async (event) => {
 					select: { media: true }
 				}
 			},
-			orderBy: { createdAt: 'desc' },
+			orderBy: [{ publishedAt: 'desc' }, { createdAt: 'desc' }],
 			take: 25
 		})
 
@@ -80,7 +80,7 @@ export const GET: RequestHandler = async (event) => {
 				content: album.description ? `<p>${escapeXML(album.description)}</p>` : '',
 				link: `${event.url.origin}/photos/${album.slug}`,
 				guid: `${event.url.origin}/photos/${album.slug}`,
-				pubDate: album.createdAt,
+				pubDate: album.publishedAt || album.createdAt,
 				updatedDate: album.updatedAt,
 				postType: 'album' as const,
 				featuredImage: null

--- a/src/routes/rss/photos/+server.ts
+++ b/src/routes/rss/photos/+server.ts
@@ -56,7 +56,7 @@ export const GET: RequestHandler = async (event) => {
 					}
 				}
 			},
-			orderBy: { createdAt: 'desc' },
+			orderBy: [{ publishedAt: 'desc' }, { createdAt: 'desc' }],
 			take: 50 // Limit to most recent 50 albums
 		})
 
@@ -82,7 +82,7 @@ export const GET: RequestHandler = async (event) => {
 						`Photography album${album.location ? ` from ${album.location}` : ''} with ${album._count.media} photo${album._count.media !== 1 ? 's' : ''}`,
 					content: album.description ? `<p>${escapeXML(album.description)}</p>` : '',
 					link: `${event.url.origin}/photos/${album.slug}`,
-					pubDate: album.createdAt,
+					pubDate: album.publishedAt || album.createdAt,
 					updatedDate: album.updatedAt,
 					guid: `${event.url.origin}/photos/${album.slug}`,
 					photoCount: album._count.media,


### PR DESCRIPTION
## Summary
A draft post held for two months and then published was advertising the **February** create time, not the **May** publish time, on the public site and in RSS. Two underlying bugs:

- **Posts** — the draft → published handler had an `!existing.publishedAt` guard that silently kept any stale value. There was also a footgun in `PATCH` where a request-body `publishedAt` could override the status-driven assignment.
- **Albums** — no `publishedAt` transition logic in the PUT handler at all. The universe feed and `/rss` + `/rss/photos` hard-coded `createdAt` as the public timestamp.

This PR brings everything in line with the existing Garden pattern: every draft → published transition stamps `publishedAt = now`; revert to draft clears it. Display side now reads `publishedAt` (with a `createdAt` fallback for legacy rows).

## Changes
- `posts/[id]` PUT + PATCH: drop the `!existing.publishedAt` guard, add clear-on-revert in PUT, remove the `publishedAt` override in PATCH.
- `albums/[id]` PUT: add the missing publishedAt transition logic.
- `/api/universe`: select album `publishedAt`, use `album.publishedAt ?? album.createdAt`, order by `[publishedAt, createdAt]`.
- `/rss` + `/rss/photos`: same album fallback + order.
- New migration `20260501000000_backfill_album_published_at`: adds the `Album.publishedAt` column (it was in `schema.prisma` but never had an `ADD COLUMN` migration) and backfills `publishedAt = createdAt` for existing published albums so they keep their currently-displayed date.

## One thing to handle manually
The specific Feb-drafted post that triggered this still has the wrong `publishedAt` in the DB. Once this ships, easiest fix is to revert it to draft in admin and republish — the new logic will stamp a fresh time. Or run a one-off `UPDATE "Post" SET "publishedAt" = ... WHERE id = ...`.

## Test plan
- [ ] `npm run check` — no new errors in touched files
- [ ] Draft a post, leave it for a moment, publish via StatusDropdown — `publishedAt` is now, distinct from `createdAt`. Public page + `/rss` show the publish time.
- [ ] Revert the post to draft — `publishedAt` clears in admin metadata. Republish — fresh timestamp (not the previous publish, not create).
- [ ] Edit a published post without changing status — `updatedAt` bumps, `publishedAt` unchanged.
- [ ] Same flow for an Album — universe card + `/rss` + `/rss/photos` reflect publish time.
- [ ] Run `npx prisma migrate deploy` against a fresh DB to confirm the migration applies cleanly (column add + backfill).