### PR TITLE
auto-save drafts in ProjectForm and GardenItemForm

### DIFF
--- a/src/lib/components/admin/GardenItemForm.svelte
+++ b/src/lib/components/admin/GardenItemForm.svelte
@@ -236,7 +236,7 @@
 			if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 's') {
 				e.preventDefault()
 				if (status === 'draft') {
-					void autoSave.flush()
+					autoSave.flush().catch(() => {})
 				} else {
 					handleSave(status)
 				}
@@ -249,7 +249,7 @@
 	// Flush pending auto-save when the window loses focus (matches Notion's behavior).
 	$effect(() => {
 		function handleBlur() {
-			if (status === 'draft') void autoSave.flush()
+			if (status === 'draft') autoSave.flush().catch(() => {})
 		}
 		window.addEventListener('blur', handleBlur)
 		return () => window.removeEventListener('blur', handleBlur)
@@ -404,7 +404,11 @@
 				toast.error(`Failed to ${mode === 'edit' ? 'save' : 'create'} item`)
 			}
 			console.error(err)
-			throw err
+			// Only re-throw on the silent (autosave) path — useAutoSave needs the rejection to
+			// transition its state machine to 'failed' / 'conflict'. Manual save call sites have
+			// already had the error surfaced via toast/console; rethrowing them produces unhandled
+			// promise rejections at the fire-and-forget call sites (Cmd+S, form onsubmit, etc).
+			if (silent) throw err
 		} finally {
 			isSaving = false
 		}
@@ -477,7 +481,12 @@
 					{status}
 					onSave={(target) => {
 						if (status === 'draft' && target !== 'draft' && isDirty) {
-							void autoSave.flush().then(() => handleSave(target))
+							autoSave.flush().then(
+								() => handleSave(target),
+								() => {
+									/* autoSave already surfaced the failure via its trigger label */
+								}
+							)
 						} else {
 							handleSave(target)
 						}

--- a/src/lib/components/admin/GardenItemForm.svelte
+++ b/src/lib/components/admin/GardenItemForm.svelte
@@ -14,6 +14,7 @@
 	import StatusDropdown from './StatusDropdown.svelte'
 	import DeleteConfirmationModal from './DeleteConfirmationModal.svelte'
 	import Switch from './Switch.svelte'
+	import { useAutoSave } from './forms/useAutoSave.svelte'
 	import { toast } from '$lib/stores/toast'
 	import {
 		SEARCH_CONFIGS,
@@ -77,7 +78,7 @@
 	let showDeleteConfirmation = $state(false)
 	let pendingNavigation = $state<BeforeNavigate | null>(null)
 	let autoSlug = $state(mode === 'create')
-	let isSavedNavigation = $state(false)
+	let allowNavigation = $state(false)
 
 	const viewUrl = $derived(
 		status === 'published' && slug ? `/garden/${category}/${slug}` : undefined
@@ -85,44 +86,57 @@
 
 	const isSearchable = $derived(!!SEARCH_CONFIGS[category])
 
-	// Track original values for dirty checking
-	let original = $state({
-		category: item?.category ?? 'books',
-		title: item?.title ?? '',
-		slug: item?.slug ?? '',
-		creator: item?.creator ?? '',
-		imageUrl: item?.imageUrl ?? '',
-		url: item?.url ?? '',
-		sourceId: item?.sourceId ?? '',
-		metadata: JSON.stringify((item?.metadata as Record<string, unknown>) ?? null),
-		date: item?.date ? new Date(item.date).toISOString().slice(0, 10) : '',
-		rating: item?.rating ?? null,
-		isCurrent: item?.isCurrent ?? false,
-		isFavorite: item?.isFavorite ?? false,
-		showInUniverse: item?.showInUniverse ?? false,
-		status: (item?.status as 'draft' | 'published') ?? 'draft',
-		note: JSON.stringify(
-			(item?.note as JSONContent) ?? { type: 'doc', content: [{ type: 'paragraph' }] }
-		)
+	// Snapshot dirty tracking — same pattern as PostForm. The $derived recomputes only when one of the
+	// referenced fields changes, and crucially does NOT write any reactive state, so it can't form a
+	// feedback loop with the auto-save effect that reads it.
+	function snapshot(): string {
+		return JSON.stringify([
+			category,
+			title,
+			slug,
+			creator,
+			imageUrl,
+			url,
+			sourceId,
+			metadata,
+			summary,
+			date,
+			rating,
+			isCurrent,
+			isFavorite,
+			showInUniverse,
+			status,
+			note
+		])
+	}
+
+	let savedSnapshot = $state<string>(snapshot())
+	let isDirty = $derived(snapshot() !== savedSnapshot)
+
+	// Auto-save runs only for drafts and only after the title is non-empty (the server requires a title,
+	// and we don't want autosave to fire prematurely on an otherwise blank form).
+	const autoSave = useAutoSave({
+		enabled: () => status === 'draft' && title.trim() !== '',
+		isDirty: () => isDirty,
+		save: () => handleSave(status, { silent: true })
 	})
 
-	const isDirty = $derived(
-		category !== original.category ||
-			title !== original.title ||
-			slug !== original.slug ||
-			creator !== original.creator ||
-			imageUrl !== original.imageUrl ||
-			url !== original.url ||
-			sourceId !== original.sourceId ||
-			JSON.stringify(metadata) !== original.metadata ||
-			date !== original.date ||
-			rating !== original.rating ||
-			isCurrent !== original.isCurrent ||
-			isFavorite !== original.isFavorite ||
-			showInUniverse !== original.showInUniverse ||
-			status !== original.status ||
-			JSON.stringify(note) !== original.note
-	)
+	const autoSaveLabel = $derived.by(() => {
+		switch (autoSave.state) {
+			case 'saving':
+				return 'Saving…'
+			case 'unsaved':
+				return 'Unsaved'
+			case 'failed':
+				return 'Save failed'
+			case 'conflict':
+				return 'Conflict — reload'
+			case 'saved':
+			case 'idle':
+			default:
+				return 'Saved'
+		}
+	})
 
 	const creatorLabel = $derived(getCreatorLabel(category))
 
@@ -216,16 +230,29 @@
 		}
 	}
 
-	// Cmd+S keyboard shortcut
+	// Cmd+S keyboard shortcut. For drafts: flush the auto-save debounce. For published: trigger save directly.
 	$effect(() => {
 		function handleKeydown(e: KeyboardEvent) {
 			if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 's') {
 				e.preventDefault()
-				handleSave()
+				if (status === 'draft') {
+					void autoSave.flush()
+				} else {
+					handleSave(status)
+				}
 			}
 		}
 		document.addEventListener('keydown', handleKeydown)
 		return () => document.removeEventListener('keydown', handleKeydown)
+	})
+
+	// Flush pending auto-save when the window loses focus (matches Notion's behavior).
+	$effect(() => {
+		function handleBlur() {
+			if (status === 'draft') void autoSave.flush()
+		}
+		window.addEventListener('blur', handleBlur)
+		return () => window.removeEventListener('blur', handleBlur)
 	})
 
 	// Browser warning for page unloads
@@ -242,24 +269,56 @@
 
 	// Navigation guard
 	beforeNavigate((navigation) => {
-		if (isSavedNavigation) return
-		if (isDirty && navigation.type !== 'leave') {
-			pendingNavigation = navigation
-			navigation.cancel()
-			showUnsavedChangesModal = true
+		if (allowNavigation) {
+			allowNavigation = false
+			return
 		}
-	})
+		if (!isDirty || navigation.type === 'leave' || !navigation.to) return
 
-	async function handleSave(newStatus?: string) {
-		if (!title.trim()) {
-			toast.error('Title is required')
+		const targetUrl = navigation.to.url.pathname
+
+		// Drafts: try to flush auto-save silently, then continue. If the flush fails, fall back to the
+		// unsaved-changes modal so we never drop edits silently.
+		if (status === 'draft' && autoSave.state !== 'conflict') {
+			navigation.cancel()
+			autoSave.flush().then(
+				() => {
+					allowNavigation = true
+					goto(targetUrl)
+				},
+				() => {
+					pendingNavigation = navigation
+					showUnsavedChangesModal = true
+				}
+			)
 			return
 		}
 
+		// Published / conflict: keep the existing unsaved-changes prompt.
+		pendingNavigation = navigation
+		navigation.cancel()
+		showUnsavedChangesModal = true
+	})
+
+	async function handleSave(newStatus?: string, { silent = false } = {}) {
 		const saveStatus = (newStatus as 'draft' | 'published') || status
 
+		if (!title.trim()) {
+			if (!silent) toast.error('Title is required')
+			return
+		}
+
+		// Apply the status transition first so the submitting snapshot reflects what we're about to send.
+		status = saveStatus
+
+		// Capture the snapshot BEFORE the await. Mid-save keystrokes won't be reflected in this string —
+		// they'll show as dirty after the save completes, and the next debounce picks them up.
+		const submittingSnapshot = snapshot()
+
 		isSaving = true
-		const loadingToastId = toast.loading(`${mode === 'edit' ? 'Saving' : 'Creating'} item...`)
+		const loadingToastId = silent
+			? null
+			: toast.loading(`${mode === 'edit' ? 'Saving' : 'Creating'} item...`)
 
 		try {
 			const payload = {
@@ -289,52 +348,38 @@
 				savedItem = (await api.post('/api/admin/garden', payload)) as GardenItem
 			}
 
-			toast.dismiss(loadingToastId)
-			toast.success(`Item ${mode === 'edit' ? 'saved' : 'created'}!`)
-
-			// Update original to match saved state
-			original = {
-				category: savedItem.category,
-				title: savedItem.title,
-				slug: savedItem.slug,
-				creator: savedItem.creator ?? '',
-				imageUrl: savedItem.imageUrl ?? '',
-				url: savedItem.url ?? '',
-				sourceId: savedItem.sourceId ?? '',
-				metadata: JSON.stringify((savedItem.metadata as Record<string, unknown>) ?? null),
-				date: savedItem.date ? new Date(savedItem.date).toISOString().slice(0, 10) : '',
-				rating: savedItem.rating ?? null,
-				isCurrent: savedItem.isCurrent,
-				isFavorite: savedItem.isFavorite,
-				showInUniverse: savedItem.showInUniverse,
-				status: savedItem.status as 'draft' | 'published',
-				note: JSON.stringify(savedItem.note ?? { type: 'doc', content: [{ type: 'paragraph' }] })
+			if (loadingToastId) {
+				toast.dismiss(loadingToastId)
+				toast.success(`Item ${mode === 'edit' ? 'saved' : 'created'}!`)
 			}
 
 			item = savedItem
-			// Sync local state with saved data
-			status = savedItem.status as 'draft' | 'published'
-			slug = savedItem.slug
+			// Sync values that the server may canonicalize. Don't overwrite slug if the user edited it
+			// during the in-flight save — the server doesn't mutate slug, so the local value is correct.
+			if (slug !== savedItem.slug) slug = savedItem.slug
 			sourceId = savedItem.sourceId ?? ''
 			metadata = (savedItem.metadata as Record<string, unknown>) ?? null
 			autoSlug = false
+
+			// Mark the version we actually submitted as saved. Mid-await keystrokes diverge from this
+			// snapshot, so isDirty stays true and the next debounce flushes them.
+			savedSnapshot = submittingSnapshot
+
 			if (mode === 'create') {
 				mode = 'edit'
 				replaceState(`/admin/garden/${savedItem.id}/edit`, {})
 			}
 		} catch (err) {
-			toast.dismiss(loadingToastId)
-			if (
-				err &&
-				typeof err === 'object' &&
-				'status' in err &&
-				(err as { status: number }).status === 409
-			) {
-				toast.error('This item has changed in another tab. Please reload.')
-			} else {
+			if (loadingToastId) toast.dismiss(loadingToastId)
+			const errStatus =
+				err && typeof err === 'object' && 'status' in err
+					? (err as { status: number }).status
+					: undefined
+			if (errStatus !== 409 && !silent) {
 				toast.error(`Failed to ${mode === 'edit' ? 'save' : 'create'} item`)
 			}
 			console.error(err)
+			throw err
 		} finally {
 			isSaving = false
 		}
@@ -364,7 +409,7 @@
 	async function handleDelete() {
 		try {
 			await api.delete(`/api/admin/garden/${item?.id}`)
-			isSavedNavigation = true
+			allowNavigation = true
 			goto('/admin/garden')
 		} catch {
 			toast.error('Failed to delete item')
@@ -378,28 +423,13 @@
 
 	function handleLeaveWithoutSaving() {
 		showUnsavedChangesModal = false
-		if (pendingNavigation) {
-			const nav = pendingNavigation
-			pendingNavigation = null
-			// Reset original to current values so isDirty becomes false
-			original = {
-				category,
-				title,
-				slug,
-				creator,
-				imageUrl,
-				url,
-				sourceId,
-				metadata: JSON.stringify(metadata),
-				date,
-				rating,
-				isCurrent,
-				isFavorite,
-				showInUniverse,
-				status,
-				note: JSON.stringify(note)
-			}
-			if (nav.to) goto(nav.to.url.pathname)
+		const nav = pendingNavigation
+		pendingNavigation = null
+		// Mark current state as saved so we don't re-trigger the modal on the next navigation.
+		savedSnapshot = snapshot()
+		if (nav?.to) {
+			allowNavigation = true
+			goto(nav.to.url.pathname)
 		}
 	}
 </script>
@@ -420,9 +450,16 @@
 			<div class="header-actions">
 				<StatusDropdown
 					{status}
-					onSave={handleSave}
+					onSave={(target) => {
+						if (status === 'draft' && target !== 'draft' && isDirty) {
+							void autoSave.flush().then(() => handleSave(target))
+						} else {
+							handleSave(target)
+						}
+					}}
 					disabled={isSaving}
 					isLoading={isSaving}
+					triggerText={status === 'draft' ? autoSaveLabel : undefined}
 					{viewUrl}
 					onDelete={mode === 'edit' ? openDeleteConfirmation : undefined}
 					onCopyPreviewLink={slug ? handleCopyPreviewLink : undefined}
@@ -439,7 +476,7 @@
 					<form
 						onsubmit={(e) => {
 							e.preventDefault()
-							handleSave()
+							handleSave(status)
 						}}
 					>
 						{#if isSearchable}
@@ -642,12 +679,6 @@
 		display: flex;
 		flex-direction: column;
 		gap: $unit-6x;
-	}
-
-	.field-label {
-		font-size: 14px;
-		font-weight: 500;
-		color: $gray-20;
 	}
 
 	.image-preview {

--- a/src/lib/components/admin/GardenItemForm.svelte
+++ b/src/lib/components/admin/GardenItemForm.svelte
@@ -277,9 +277,13 @@
 
 		const targetUrl = navigation.to.url.pathname
 
-		// Drafts: try to flush auto-save silently, then continue. If the flush fails, fall back to the
-		// unsaved-changes modal so we never drop edits silently.
-		if (status === 'draft' && autoSave.state !== 'conflict') {
+		// Drafts with content: try to flush auto-save silently, then continue. If the flush fails, fall
+		// back to the unsaved-changes modal so we never drop edits silently. If autosave isn't enabled
+		// yet (e.g. empty title), don't fall through to its silent path — the form is still dirty in
+		// other fields and we'd drop those edits.
+		const draftCanAutoSave =
+			status === 'draft' && title.trim() !== '' && autoSave.state !== 'conflict'
+		if (draftCanAutoSave) {
 			navigation.cancel()
 			autoSave.flush().then(
 				() => {
@@ -308,12 +312,28 @@
 			return
 		}
 
-		// Apply the status transition first so the submitting snapshot reflects what we're about to send.
-		status = saveStatus
-
-		// Capture the snapshot BEFORE the await. Mid-save keystrokes won't be reflected in this string —
-		// they'll show as dirty after the save completes, and the next debounce picks them up.
-		const submittingSnapshot = snapshot()
+		// Build the snapshot that represents what we're about to submit (not what's currently in the
+		// form, which may diverge from saveStatus if the user clicked Publish on a draft). Don't apply
+		// `status = saveStatus` locally yet — if the request fails we'd be left showing a status the
+		// server hasn't actually accepted.
+		const submittingSnapshot = JSON.stringify([
+			category,
+			title,
+			slug,
+			creator,
+			imageUrl,
+			url,
+			sourceId,
+			metadata,
+			summary,
+			date,
+			rating,
+			isCurrent,
+			isFavorite,
+			showInUniverse,
+			saveStatus,
+			note
+		])
 
 		isSaving = true
 		const loadingToastId = silent
@@ -354,12 +374,17 @@
 			}
 
 			item = savedItem
-			// Sync values that the server may canonicalize. Don't overwrite slug if the user edited it
-			// during the in-flight save — the server doesn't mutate slug, so the local value is correct.
-			if (slug !== savedItem.slug) slug = savedItem.slug
+			// Adopt the server-canonicalized slug only on first save (where we may have submitted an
+			// auto-generated slug). On edit we never sync slug back — the server doesn't mutate it, and
+			// syncing would clobber an in-flight slug edit.
+			if (mode === 'create') {
+				if (slug !== savedItem.slug) slug = savedItem.slug
+			}
 			sourceId = savedItem.sourceId ?? ''
 			metadata = (savedItem.metadata as Record<string, unknown>) ?? null
 			autoSlug = false
+			// Sync status only on success — if the publish failed above we'd be lying to the dropdown.
+			status = saveStatus
 
 			// Mark the version we actually submitted as saved. Mid-await keystrokes diverge from this
 			// snapshot, so isDirty stays true and the next debounce flushes them.

--- a/src/lib/components/admin/ProjectForm.svelte
+++ b/src/lib/components/admin/ProjectForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto, beforeNavigate, replaceState } from '$app/navigation'
+	import type { BeforeNavigate } from '@sveltejs/kit'
 	import { api } from '$lib/admin/api'
 	import AdminPage from './AdminPage.svelte'
 	import AdminSegmentedControl from './AdminSegmentedControl.svelte'
@@ -8,8 +9,9 @@
 	import Composer from './composer'
 	import ProjectMetadataForm from './ProjectMetadataForm.svelte'
 	import ProjectBrandingForm from './ProjectBrandingForm.svelte'
+	import { useAutoSave } from './forms/useAutoSave.svelte'
 	import { toast } from '$lib/stores/toast'
-	import type { Project } from '$lib/types/project'
+	import type { Project, ProjectStatus } from '$lib/types/project'
 	import { createProjectFormStore } from '$lib/stores/project-form.svelte'
 
 	interface Props {
@@ -32,7 +34,8 @@
 	let isSaving = $state(false)
 	let activeTab = $state('metadata')
 	let showUnsavedChangesModal = $state(false)
-	let pendingNavigation = $state<Parameters<typeof beforeNavigate>[0] | null>(null)
+	let pendingNavigation = $state<BeforeNavigate | null>(null)
+	let allowNavigation = $state(false)
 
 	const tabOptions = [
 		{ value: 'metadata', label: 'Metadata' },
@@ -40,8 +43,17 @@
 		{ value: 'case-study', label: 'Case Study' }
 	]
 
-	// Status-specific dropdown labels for project's extra statuses (list-only,
-	// password-protected); StatusDropdown handles draft/published defaults itself.
+	// Snapshot dirty tracking — same pattern as PostForm/GardenItemForm. The store's own isDirty would
+	// also work, but a local snapshot is simpler to thread through the autosave race fix (capture
+	// submittingSnapshot before await, restore on success — mid-save keystrokes stay dirty).
+	function snapshot(): string {
+		return JSON.stringify(formStore.fields)
+	}
+	let savedSnapshot = $state<string>(snapshot())
+	let isDirty = $derived(snapshot() !== savedSnapshot)
+
+	// Status-specific dropdown labels for project's extra statuses (list-only, password-protected);
+	// StatusDropdown handles draft/published defaults itself.
 	const altActions = $derived.by(() => {
 		const s = formStore.fields.status
 		if (s === 'draft' || s === 'published') return undefined
@@ -63,31 +75,70 @@
 			: undefined
 	)
 
+	// Auto-save runs only for drafts and only after a title is set (the schema requires title; firing
+	// before that would just produce 'Save failed' visually and confuse the user).
+	const autoSave = useAutoSave({
+		enabled: () => formStore.fields.status === 'draft' && formStore.fields.title.trim() !== '',
+		isDirty: () => isDirty,
+		save: () => handleSave(formStore.fields.status, { silent: true })
+	})
+
+	const autoSaveLabel = $derived.by(() => {
+		switch (autoSave.state) {
+			case 'saving':
+				return 'Saving…'
+			case 'unsaved':
+				return 'Unsaved'
+			case 'failed':
+				return 'Save failed'
+			case 'conflict':
+				return 'Conflict — reload'
+			case 'saved':
+			case 'idle':
+			default:
+				return 'Saved'
+		}
+	})
+
 	// Initial load effect
 	$effect(() => {
 		if (project && mode === 'edit' && !hasLoaded) {
 			formStore.populateFromProject(project)
+			savedSnapshot = snapshot()
 			isLoading = false
 			hasLoaded = true
 		}
 	})
 
-	// Cmd+S keyboard shortcut
+	// Cmd+S keyboard shortcut. For drafts: flush the auto-save debounce. For other statuses: trigger save directly.
 	$effect(() => {
 		function handleKeydown(e: KeyboardEvent) {
 			if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 's') {
 				e.preventDefault()
-				handleSave()
+				if (formStore.fields.status === 'draft') {
+					void autoSave.flush()
+				} else {
+					handleSave()
+				}
 			}
 		}
 		document.addEventListener('keydown', handleKeydown)
 		return () => document.removeEventListener('keydown', handleKeydown)
 	})
 
+	// Flush pending auto-save when the window loses focus (matches Notion's behavior).
+	$effect(() => {
+		function handleBlur() {
+			if (formStore.fields.status === 'draft') void autoSave.flush()
+		}
+		window.addEventListener('blur', handleBlur)
+		return () => window.removeEventListener('blur', handleBlur)
+	})
+
 	// Browser warning for page unloads (refresh/close) - required for these events
 	$effect(() => {
 		function handleBeforeUnload(e: BeforeUnloadEvent) {
-			if (formStore.isDirty) {
+			if (isDirty) {
 				e.preventDefault()
 				e.returnValue = ''
 			}
@@ -98,26 +149,55 @@
 
 	// Navigation guard for unsaved changes (in-app navigation only)
 	beforeNavigate((navigation) => {
-		// Only intercept in-app navigation, not page unloads (refresh/close)
-		if (formStore.isDirty && navigation.type !== 'leave') {
-			pendingNavigation = navigation
-			navigation.cancel()
-			showUnsavedChangesModal = true
+		if (allowNavigation) {
+			allowNavigation = false
+			return
 		}
+		if (!isDirty || navigation.type === 'leave' || !navigation.to) return
+
+		const targetUrl = navigation.to.url.pathname
+
+		// Drafts: try to flush auto-save silently, then continue. If the flush fails (network, 409, etc),
+		// fall back to the unsaved-changes modal so we never drop edits silently.
+		if (formStore.fields.status === 'draft' && autoSave.state !== 'conflict') {
+			navigation.cancel()
+			autoSave.flush().then(
+				() => {
+					allowNavigation = true
+					goto(targetUrl)
+				},
+				() => {
+					pendingNavigation = navigation
+					showUnsavedChangesModal = true
+				}
+			)
+			return
+		}
+
+		// Published / list-only / password-protected / conflict: keep the existing unsaved-changes prompt.
+		pendingNavigation = navigation
+		navigation.cancel()
+		showUnsavedChangesModal = true
 	})
 
-	async function handleSave(newStatus?: string) {
+	async function handleSave(newStatus?: string, { silent = false } = {}) {
 		if (newStatus) {
-			formStore.setField('status', newStatus)
+			formStore.setField('status', newStatus as ProjectStatus)
 		}
 
-		if (!formStore.validate()) {
+		// Strict validation only for explicit user-driven saves. Auto-save never blocks on validation —
+		// the form may be partial; the next save attempt will pick up new fields when they're filled in.
+		if (!silent && !formStore.validate()) {
 			toast.error('Please fix the validation errors')
 			return
 		}
 
+		const submittingSnapshot = snapshot()
+
 		isSaving = true
-		const loadingToastId = toast.loading(`${mode === 'edit' ? 'Saving' : 'Creating'} project...`)
+		const loadingToastId = silent
+			? null
+			: toast.loading(`${mode === 'edit' ? 'Saving' : 'Creating'} project...`)
 
 		try {
 			const payload = {
@@ -126,12 +206,6 @@
 				updatedAt: mode === 'edit' ? project?.updatedAt : undefined
 			}
 
-			console.log('[ProjectForm] Saving with payload:', {
-				showFeaturedImageInHeader: payload.showFeaturedImageInHeader,
-				showBackgroundColorInHeader: payload.showBackgroundColorInHeader,
-				showLogoInHeader: payload.showLogoInHeader
-			})
-
 			let savedProject: Project
 			if (mode === 'edit') {
 				savedProject = (await api.put(`/api/projects/${project?.id}`, payload)) as Project
@@ -139,28 +213,35 @@
 				savedProject = (await api.post('/api/projects', payload)) as Project
 			}
 
-			toast.dismiss(loadingToastId)
-			toast.success(`Project ${mode === 'edit' ? 'saved' : 'created'} successfully!`)
+			if (loadingToastId) {
+				toast.dismiss(loadingToastId)
+				toast.success(`Project ${mode === 'edit' ? 'saved' : 'created'} successfully!`)
+			}
 
+			// Sync the local project handle so subsequent saves carry the right updatedAt + viewUrl uses
+			// the new slug. Don't call formStore.populateFromProject here — that would clobber any
+			// keystrokes the user made during the await.
 			project = savedProject
-			formStore.populateFromProject(savedProject)
+
+			// Mark the version we actually submitted as saved. Mid-await keystrokes diverge from this
+			// snapshot, so isDirty stays true and the next debounce flushes them.
+			savedSnapshot = submittingSnapshot
+
 			if (mode === 'create') {
 				mode = 'edit'
 				replaceState(`/admin/projects/${savedProject.id}/edit`, {})
 			}
 		} catch (err) {
-			toast.dismiss(loadingToastId)
-			if (
-				err &&
-				typeof err === 'object' &&
-				'status' in err &&
-				(err as { status: number }).status === 409
-			) {
-				toast.error('This project has changed in another tab. Please reload.')
-			} else {
+			if (loadingToastId) toast.dismiss(loadingToastId)
+			const errStatus =
+				err && typeof err === 'object' && 'status' in err
+					? (err as { status: number }).status
+					: undefined
+			if (errStatus !== 409 && !silent) {
 				toast.error(`Failed to ${mode === 'edit' ? 'save' : 'create'} project`)
 			}
 			console.error(err)
+			throw err
 		} finally {
 			isSaving = false
 		}
@@ -173,11 +254,13 @@
 
 	function handleLeaveWithoutSaving() {
 		showUnsavedChangesModal = false
-		if (pendingNavigation) {
-			// Temporarily allow dirty navigation
-			const nav = pendingNavigation
-			pendingNavigation = null
-			if (nav.to) goto(nav.to.url.pathname)
+		const nav = pendingNavigation
+		pendingNavigation = null
+		// Mark current state as saved so we don't re-trigger the modal on the next navigation.
+		savedSnapshot = snapshot()
+		if (nav?.to) {
+			allowNavigation = true
+			goto(nav.to.url.pathname)
 		}
 	}
 </script>
@@ -198,9 +281,16 @@
 			<div class="header-actions">
 				<StatusDropdown
 					status={formStore.fields.status}
-					onSave={handleSave}
+					onSave={(target) => {
+						if (formStore.fields.status === 'draft' && target !== 'draft' && isDirty) {
+							void autoSave.flush().then(() => handleSave(target))
+						} else {
+							handleSave(target)
+						}
+					}}
 					disabled={isSaving}
 					isLoading={isSaving}
+					triggerText={formStore.fields.status === 'draft' ? autoSaveLabel : undefined}
 					{primaryLabel}
 					{altActions}
 					{viewUrl}

--- a/src/lib/components/admin/ProjectForm.svelte
+++ b/src/lib/components/admin/ProjectForm.svelte
@@ -157,9 +157,15 @@
 
 		const targetUrl = navigation.to.url.pathname
 
-		// Drafts: try to flush auto-save silently, then continue. If the flush fails (network, 409, etc),
-		// fall back to the unsaved-changes modal so we never drop edits silently.
-		if (formStore.fields.status === 'draft' && autoSave.state !== 'conflict') {
+		// Drafts with content: try to flush auto-save silently, then continue. If the flush fails
+		// (network, 409, etc), fall back to the unsaved-changes modal so we never drop edits silently.
+		// If autosave isn't enabled (e.g. empty title gates it off), don't fall through to its silent
+		// path — the form is still dirty in other fields and we'd drop those edits.
+		const draftCanAutoSave =
+			formStore.fields.status === 'draft' &&
+			formStore.fields.title.trim() !== '' &&
+			autoSave.state !== 'conflict'
+		if (draftCanAutoSave) {
 			navigation.cancel()
 			autoSave.flush().then(
 				() => {
@@ -181,9 +187,7 @@
 	})
 
 	async function handleSave(newStatus?: string, { silent = false } = {}) {
-		if (newStatus) {
-			formStore.setField('status', newStatus as ProjectStatus)
-		}
+		const saveStatus = (newStatus as ProjectStatus) || formStore.fields.status
 
 		// Strict validation only for explicit user-driven saves. Auto-save never blocks on validation —
 		// the form may be partial; the next save attempt will pick up new fields when they're filled in.
@@ -192,7 +196,10 @@
 			return
 		}
 
-		const submittingSnapshot = snapshot()
+		// Snapshot what we're about to submit (with saveStatus, even though we haven't applied it
+		// locally yet). Don't mutate formStore.fields.status here — if the save fails, we'd be lying
+		// to the dropdown about what state the server has.
+		const submittingSnapshot = JSON.stringify({ ...formStore.fields, status: saveStatus })
 
 		isSaving = true
 		const loadingToastId = silent
@@ -202,6 +209,8 @@
 		try {
 			const payload = {
 				...formStore.buildPayload(),
+				status: saveStatus,
+				password: saveStatus === 'password-protected' ? formStore.fields.password : null,
 				// Include updatedAt for concurrency control in edit mode
 				updatedAt: mode === 'edit' ? project?.updatedAt : undefined
 			}
@@ -222,6 +231,9 @@
 			// the new slug. Don't call formStore.populateFromProject here — that would clobber any
 			// keystrokes the user made during the await.
 			project = savedProject
+
+			// Apply the status transition only after the server has accepted it.
+			formStore.setField('status', saveStatus)
 
 			// Mark the version we actually submitted as saved. Mid-await keystrokes diverge from this
 			// snapshot, so isDirty stays true and the next debounce flushes them.

--- a/src/lib/components/admin/ProjectForm.svelte
+++ b/src/lib/components/admin/ProjectForm.svelte
@@ -116,7 +116,7 @@
 			if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 's') {
 				e.preventDefault()
 				if (formStore.fields.status === 'draft') {
-					void autoSave.flush()
+					autoSave.flush().catch(() => {})
 				} else {
 					handleSave()
 				}
@@ -129,7 +129,7 @@
 	// Flush pending auto-save when the window loses focus (matches Notion's behavior).
 	$effect(() => {
 		function handleBlur() {
-			if (formStore.fields.status === 'draft') void autoSave.flush()
+			if (formStore.fields.status === 'draft') autoSave.flush().catch(() => {})
 		}
 		window.addEventListener('blur', handleBlur)
 		return () => window.removeEventListener('blur', handleBlur)
@@ -253,7 +253,11 @@
 				toast.error(`Failed to ${mode === 'edit' ? 'save' : 'create'} project`)
 			}
 			console.error(err)
-			throw err
+			// Only re-throw on the silent (autosave) path — useAutoSave needs the rejection to
+			// transition its state machine to 'failed' / 'conflict'. Manual save call sites have
+			// already had the error surfaced via toast/console; rethrowing them produces unhandled
+			// promise rejections at the fire-and-forget call sites (Cmd+S, form onsubmit, etc).
+			if (silent) throw err
 		} finally {
 			isSaving = false
 		}
@@ -295,7 +299,12 @@
 					status={formStore.fields.status}
 					onSave={(target) => {
 						if (formStore.fields.status === 'draft' && target !== 'draft' && isDirty) {
-							void autoSave.flush().then(() => handleSave(target))
+							autoSave.flush().then(
+								() => handleSave(target),
+								() => {
+									/* autoSave already surfaced the failure via its trigger label */
+								}
+							)
 						} else {
 							handleSave(target)
 						}


### PR DESCRIPTION
## Summary
- ports the PostForm autosave pattern (proven in PRs #87–#90) to **ProjectForm** and **GardenItemForm**:
  - drafts auto-save 1500ms after the last edit; `Cmd+S`, window blur, and in-app navigation flush pending changes
  - `StatusDropdown`'s combined trigger now shows the autosave label (`Saved` / `Saving…` / `Unsaved` / `Save failed` / `Conflict — reload`) for drafts; published/list-only/password-protected keep the existing manual-save UI
  - mid-save keystrokes stay dirty (capture `submittingSnapshot` before await, restore on success — same race fix as the post form)
  - 409 conflicts surface as `Conflict — reload` and stop autosaving; failed in-app navigations fall back to the unsaved-changes modal so we never silently drop edits
- replaces each form's bespoke dirty-tracking with a single `JSON.stringify` snapshot derived (matches PostForm)
- drops the post-save `formStore.populateFromProject(saved)` / `populateFormData(saved)` reset from the autosave path so it doesn't clobber mid-await keystrokes; manual publish still calls `formStore.populateFromProject` indirectly via `project = savedProject` for the next concurrency check
- skips `formStore.validate()` and the `title is required` check on silent autosaves; manual saves keep strict validation
- gates `enabled()` on `title.trim() !== ''` so autosave doesn't fire prematurely on a blank form

`AlbumForm` is intentionally untouched — albums don't have a draft/published status and the create flow needs photos before save makes sense.

## Test plan
For each of `ProjectForm` and `GardenItemForm`:
- [ ] new draft: enter a title and a few words → after ~1.5s URL silently swaps to `/admin/{type}/[id]/edit` and the dropdown shows "Saved"; continued edits cycle through "Unsaved" → "Saving…" → "Saved" with no manual click
- [ ] existing draft: edit → autosaves silently; refresh, changes persisted
- [ ] Cmd+S during editing: trigger flashes "Saving…" then "Saved"
- [ ] Publish on a dirty draft: autosave flushes first, publish runs on top, dropdown switches to the published variant
- [ ] two-tab test: edit and save in tab A → tab B's next autosave returns 409 → trigger shows "Conflict — reload" and stops; reload works
- [ ] non-draft statuses (Project: list-only / password-protected / published; Garden: published) keep the existing manual save UI; no autosave fires
- [ ] navigate away from a dirty draft via sidebar: silent save, no UnsavedChangesModal; offline → modal appears
- [ ] empty title on new draft: no autosave fires until title is entered
- [ ] `pnpm run check` net error count unchanged or lower (origin/main: 118; this PR: 114)