### PR TITLE
strip embedded HTML from garden item summaries

### DIFF
--- a/src/lib/utils/content.ts
+++ b/src/lib/utils/content.ts
@@ -10,6 +10,29 @@ const SANITIZE_CONFIG = {
 
 const sanitize = (html: string): string => DOMPurify.sanitize(html, SANITIZE_CONFIG)
 
+const SUMMARY_ENTITIES: Record<string, string> = {
+	'&amp;': '&',
+	'&lt;': '<',
+	'&gt;': '>',
+	'&quot;': '"',
+	'&#39;': "'",
+	'&nbsp;': ' '
+}
+
+// Strip HTML out of imported summaries (e.g. AniList synopses ship with <br>,
+// <i>, etc. embedded in the description text). Converts <br> to newlines so
+// the rendering element's `white-space: pre-line` produces paragraph breaks.
+export const cleanSummary = (raw: string | null | undefined): string => {
+	if (!raw) return ''
+	return raw
+		.replace(/<br\s*\/?>/gi, '\n')
+		.replace(/<[^>]+>/g, '')
+		.replace(/&(amp|lt|gt|quot|#39|nbsp);/g, (m) => SUMMARY_ENTITIES[m] ?? m)
+		.replace(/[ \t]+\n/g, '\n')
+		.replace(/\n{3,}/g, '\n\n')
+		.trim()
+}
+
 // Content node types for rendering
 interface ContentNode {
 	type: string

--- a/src/routes/garden/[category]/[slug]/+page.svelte
+++ b/src/routes/garden/[category]/[slug]/+page.svelte
@@ -3,7 +3,7 @@
 	import BackButton from '$components/BackButton.svelte'
 	import HeartButton from '$components/HeartButton.svelte'
 	import { generateMetaTags } from '$lib/utils/metadata'
-	import { renderEdraContent } from '$lib/utils/content'
+	import { renderEdraContent, cleanSummary } from '$lib/utils/content'
 	import { formatDate } from '$lib/utils/date'
 	import StarIcon from '$icons/star.svg?component'
 	import CheckboxIcon from '$icons/checkbox-checked.svg?component'
@@ -32,6 +32,7 @@
 	const renderedNote = $derived(
 		data.item?.note ? renderEdraContent(data.item.note).replace(/(<p><br><\/p>\s*)+$/, '') : ''
 	)
+	const cleanedSummary = $derived(cleanSummary(data.item?.summary))
 	const dateStr = $derived(data.item?.date ? data.item.date.toString() : '')
 	const year = $derived.by(() => {
 		if (!data.item?.date) return null
@@ -127,9 +128,9 @@
 							<p class="item-subtitle">{subtitle}</p>
 						{/if}
 
-						{#if data.item.summary}
+						{#if cleanedSummary}
 							<p class="item-summary" class:collapsed={!summaryExpanded} bind:this={summaryEl}>
-								{data.item.summary}
+								{cleanedSummary}
 							</p>
 							{#if summaryOverflows || summaryExpanded}
 								<button class="summary-toggle" onclick={() => (summaryExpanded = !summaryExpanded)}>


### PR DESCRIPTION
## Summary
- Garden detail pages were showing literal `<br>`, `<br><br>`, and `<i>...</i>` tags inside the summary blurb (most visible on AniList-imported manga like Fullmetal Alchemist) because the field was rendered as escaped text.
- Adds a `cleanSummary` helper in `src/lib/utils/content.ts` that converts `<br>` to newlines, strips remaining tags, decodes the common HTML entities, and collapses extra whitespace.
- Wires it into `src/routes/garden/[category]/[slug]/+page.svelte` via a `$derived` value. Existing markup and CSS (`white-space: pre-line` + `-webkit-line-clamp: 3`) are unchanged, so the "Read more" toggle still works and `\n\n` separators render as visible paragraph breaks.

No DB migration or import-side changes — render-time cleanup only.

## Test plan
- [ ] `npm run dev`, open the Fullmetal Alchemist garden item: no literal `<br>` / `<i>` visible; `(Source: VIZ Media)` and `Note: ...` blocks separated by blank lines; "Read more" expands/collapses.
- [ ] Spot-check a non-manga item (movie/book) — plaintext summaries render unchanged.
- [ ] `npm run check` and `npm run lint` pass.