### PR TITLE
mobile photos: restore scroll on back, swipe + prev/next traversal

### DIFF
--- a/src/lib/components/PhotoViewEnhanced.svelte
+++ b/src/lib/components/PhotoViewEnhanced.svelte
@@ -40,20 +40,8 @@
 	function checkIfUltrawide() {
 		if (width && height) {
 			isUltrawide = width / height > 2
-			console.log('Ultrawide check from props:', {
-				width,
-				height,
-				ratio: width / height,
-				isUltrawide
-			})
 		} else if (imageRef && imageLoaded) {
 			isUltrawide = imageRef.naturalWidth / imageRef.naturalHeight > 2
-			console.log('Ultrawide check from image:', {
-				naturalWidth: imageRef.naturalWidth,
-				naturalHeight: imageRef.naturalHeight,
-				ratio: imageRef.naturalWidth / imageRef.naturalHeight,
-				isUltrawide
-			})
 		}
 	}
 
@@ -199,7 +187,6 @@
 </div>
 
 <style lang="scss">
-
 	.photo-view {
 		display: flex;
 		justify-content: center;

--- a/src/routes/photos/+page.svelte
+++ b/src/routes/photos/+page.svelte
@@ -151,31 +151,45 @@
 		})
 	)
 
-	// Snapshot to preserve scroll position
+	// Snapshot to preserve scroll position AND the photos loaded via infinite
+	// scroll — without them the restored page is only one server page tall and
+	// window.scrollTo clamps back to the top (most visible on mobile).
 	export const snapshot: Snapshot<{
 		scrollY: number
 		horizontalScroll: number | undefined
+		photos: Photo[]
+		offset: number
 	}> = {
 		capture: () => {
-			if (!browser) return { scrollY: 0, horizontalScroll: undefined }
+			if (!browser) return { scrollY: 0, horizontalScroll: undefined, photos: [], offset: 0 }
 
 			return {
 				scrollY: window.scrollY,
-				horizontalScroll: document.querySelector('.horizontal-scroll')?.scrollLeft
+				horizontalScroll: document.querySelector('.horizontal-scroll')?.scrollLeft,
+				photos: allPhotos,
+				offset: currentOffset
 			}
 		},
-		restore: (data) => {
+		restore: (snap) => {
 			if (!browser) return
+
+			// Re-hydrate everything loaded beyond the initial server page first,
+			// so the document is tall enough for the scroll restore below
+			if (snap.photos?.length > allPhotos.length) {
+				allPhotos = snap.photos
+				currentOffset = snap.offset
+				loadedPhotoIds = new Set(snap.photos.map((photo) => photo.id))
+			}
 
 			// Small delay to ensure content is rendered
 			setTimeout(() => {
-				if (data.scrollY) {
-					window.scrollTo(0, data.scrollY)
+				if (snap.scrollY) {
+					window.scrollTo(0, snap.scrollY)
 				}
-				if (data.horizontalScroll !== undefined) {
+				if (snap.horizontalScroll !== undefined) {
 					const element = document.querySelector('.horizontal-scroll')
 					if (element) {
-						element.scrollLeft = data.horizontalScroll
+						element.scrollLeft = snap.horizontalScroll
 					}
 				}
 			}, 10)

--- a/src/routes/photos/[id]/+page.svelte
+++ b/src/routes/photos/[id]/+page.svelte
@@ -129,6 +129,44 @@
 		}
 	}
 
+	// Swipe navigation (mobile). The photo container uses touch-action:
+	// pinch-zoom, so single-finger horizontal swipes reach us; a second
+	// finger (pinch) cancels the gesture via the touches-length guard.
+	let touchStartX = 0
+	let touchStartY = 0
+	let touchStartTime = 0
+	let touchActive = false
+
+	function handleTouchStart(e: TouchEvent) {
+		if (e.touches.length !== 1) {
+			touchActive = false
+			return
+		}
+		touchActive = true
+		touchStartX = e.touches[0].clientX
+		touchStartY = e.touches[0].clientY
+		touchStartTime = Date.now()
+	}
+
+	function handleTouchEnd(e: TouchEvent) {
+		if (!touchActive) return
+		touchActive = false
+
+		const dx = e.changedTouches[0].clientX - touchStartX
+		const dy = e.changedTouches[0].clientY - touchStartY
+		const elapsed = Date.now() - touchStartTime
+
+		// Quick, mostly-horizontal swipes only — taps and scrolls fall through
+		if (elapsed > 600) return
+		if (Math.abs(dx) < 48 || Math.abs(dx) < Math.abs(dy) * 1.5) return
+
+		if (dx < 0) {
+			navigateToPhoto(adjacentPhotos().next)
+		} else {
+			navigateToPhoto(adjacentPhotos().prev)
+		}
+	}
+
 	// Set default button positions when component mounts
 	$effect(() => {
 		if (!photo) return
@@ -384,7 +422,7 @@
 		onmousemove={handleMouseMove}
 		onmouseleave={handleMouseLeave}
 	>
-		<div class="photo-content-wrapper">
+		<div class="photo-content-wrapper" ontouchstart={handleTouchStart} ontouchend={handleTouchEnd}>
 			<PhotoViewEnhanced
 				src={photo.url}
 				alt={photo.caption}
@@ -394,6 +432,30 @@
 				height={photo.height}
 			/>
 		</div>
+
+		<!-- Static prev/next for touch devices (floating buttons are desktop-only) -->
+		{#if adjacentPhotos().prev || adjacentPhotos().next}
+			<nav class="mobile-photo-nav" aria-label="Photo navigation">
+				<button
+					class="mobile-nav-button"
+					type="button"
+					disabled={!adjacentPhotos().prev}
+					onclick={() => navigateToPhoto(adjacentPhotos().prev)}
+					aria-label="Previous photo"
+				>
+					<ArrowLeft />
+				</button>
+				<button
+					class="mobile-nav-button"
+					type="button"
+					disabled={!adjacentPhotos().next}
+					onclick={() => navigateToPhoto(adjacentPhotos().next)}
+					aria-label="Next photo"
+				>
+					<ArrowRight />
+				</button>
+			</nav>
+		{/if}
 
 		<!-- Adjacent Photos Navigation -->
 		<div class="adjacent-navigation">
@@ -525,6 +587,47 @@
 		// Hide on mobile and tablet
 		@include breakpoint('tablet') {
 			display: none;
+		}
+	}
+
+	// Static touch navigation — shown where the floating buttons are hidden
+	.mobile-photo-nav {
+		display: none;
+		width: 100%;
+		max-width: 700px;
+		margin: 0 auto;
+		justify-content: space-between;
+
+		@include breakpoint('tablet') {
+			display: flex;
+		}
+	}
+
+	.mobile-nav-button {
+		width: 44px;
+		height: 44px;
+		border: none;
+		padding: 0;
+		background: $gray-95;
+		cursor: pointer;
+		border-radius: 50%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+
+		&:disabled {
+			opacity: 0.35;
+			cursor: default;
+		}
+
+		:global(svg) {
+			stroke: $gray-10;
+			width: 16px;
+			height: 16px;
+			fill: none;
+			stroke-width: 2px;
+			stroke-linecap: round;
+			stroke-linejoin: round;
 		}
 	}
 


### PR DESCRIPTION
## Summary

Two mobile fixes for the photos section:

- **Back from a photo no longer jumps to the top of the index.** The snapshot only saved `scrollY`, not the photos loaded via infinite scroll — so on back-nav the page was one server page (20 photos) tall and the scroll restore clamped to the top. The snapshot now also captures the loaded photo array + offset and re-hydrates them before restoring scroll.
- **Photos are traversable on mobile.** The floating prev/next buttons are desktop-only (cursor-follow) and keyboard arrows don't exist on touch. Added swipe left/right on the photo (guarded so taps, vertical scrolls, and pinch-zoom don't trigger it) plus static prev/next buttons below the photo, shown under the same tablet breakpoint that hides the floating ones — every screen gets exactly one of the two.

Also dropped two debug `console.log`s in `PhotoViewEnhanced` that fired on every photo view.

Verified in a 390×844 browser: loaded 72 photos, opened one deep in the list, went back → all 72 re-hydrated and scroll restored (3904 vs 4000 pre-nav, small image-settle drift). Next button and swipe both navigate; tap/vertical/diagonal gestures don't.

## Test plan

- [ ] On a phone: scroll deep into /photos (past ~20 photos), tap a photo, go back — you land where you left off
- [ ] On the photo page: swipe left/right to traverse; tap still opens zoom; pinch-zoom unaffected
- [ ] Prev/next buttons visible below the photo on mobile, disabled at either end
- [ ] Desktop floating nav unchanged