### PR TITLE
editor design polish: parity with published pages, hover toolbars everywhere

### DIFF
--- a/src/assets/styles/content.scss
+++ b/src/assets/styles/content.scss
@@ -10,7 +10,7 @@
 	margin: $unit-3x 0;
 
 	@media (max-width: 600px) {
-		grid-template-columns: repeat(2, 1fr);
+		grid-template-columns: repeat(min(var(--gallery-columns, 3), 2), 1fr);
 	}
 
 	.gallery-item {
@@ -29,6 +29,25 @@
 			font-size: $font-size-small;
 			color: $gray-40;
 			line-height: 1.4;
+		}
+	}
+}
+
+.content-gallery--masonry {
+	display: block;
+	column-count: var(--gallery-columns, 3);
+	column-gap: $unit-2x;
+
+	@media (max-width: 600px) {
+		column-count: min(var(--gallery-columns, 3), 2);
+	}
+
+	.gallery-item {
+		break-inside: avoid;
+		margin-bottom: $unit-2x;
+
+		img {
+			height: auto;
 		}
 	}
 }

--- a/src/assets/styles/themes.scss
+++ b/src/assets/styles/themes.scss
@@ -1,6 +1,9 @@
 @use 'variables' as *;
 
 :root {
+	// Shared shape tokens (for plain-CSS consumers like the Edra editor styles)
+	--corner-radius: #{$corner-radius};
+
 	// Base page colors
 	--bg-color: #{$gray-80};
 	--page-color: #{$gray-100};

--- a/src/lib/components/DynamicPostContent.svelte
+++ b/src/lib/components/DynamicPostContent.svelte
@@ -367,7 +367,7 @@
 			:global(video) {
 				width: 100%;
 				height: auto;
-				border-radius: $unit;
+				border-radius: $corner-radius;
 			}
 		}
 

--- a/src/lib/components/ProjectContent.svelte
+++ b/src/lib/components/ProjectContent.svelte
@@ -106,7 +106,7 @@
 			:global(img) {
 				width: 100%;
 				height: auto;
-				border-radius: $unit;
+				border-radius: $corner-radius;
 			}
 
 			:global(figcaption) {

--- a/src/lib/components/edra/editor.css
+++ b/src/lib/components/edra/editor.css
@@ -43,6 +43,13 @@
 	margin-bottom: 1rem;
 }
 
+.tiptap h3,
+.tiptap h4,
+.tiptap h5,
+.tiptap h6 {
+	margin-bottom: 0.75rem;
+}
+
 .tiptap h1 {
 	font-size: 2.25rem;
 	font-weight: 800;
@@ -286,31 +293,68 @@ ul[data-type='taskList'] li[data-checked='true'] div {
 	--table-hover-transition: 200ms ease-in-out;
 	--table-focus-ring: 2px;
 }
+/* Full-width table, with a gutter carved out via negative margin so the
+   hover grip handles (top -0.9rem / left -0.9rem) still have room to render */
 .ProseMirror .tableWrapper {
-	padding: 1.25rem 1rem;
-	margin: 0;
-	margin: 0.5rem 0;
+	padding: 1.25rem 0 0 1rem;
+	margin: 0.5rem 0 0.5rem -1rem;
 	overflow-x: auto;
 }
 
+/* Matches the published table look (.content-table): outer border with
+   rounded corners, inner dividers only. border-collapse: separate is what
+   lets the radius actually render. */
 .ProseMirror table {
 	box-sizing: border-box;
 	width: 100%;
 	margin-top: 1rem;
 	margin-bottom: 1rem;
-	border-collapse: collapse;
+	border-collapse: separate;
+	border-spacing: 0;
 	border: var(--table-border-size) solid var(--table-border);
-	border-radius: 0.25rem;
+	border-radius: var(--corner-radius);
 }
 
 .ProseMirror table td,
 .ProseMirror table th {
 	position: relative;
 	min-width: 100px;
-	padding: 0.5rem;
+	padding: 0.5rem 1rem;
 	vertical-align: top;
 	text-align: left;
-	border: var(--table-border-size) solid var(--table-border);
+	border-right: var(--table-border-size) solid var(--table-border);
+	border-bottom: var(--table-border-size) solid var(--table-border);
+}
+
+.ProseMirror table td:last-child,
+.ProseMirror table th:last-child {
+	border-right: 0;
+}
+
+.ProseMirror table tr:last-child td,
+.ProseMirror table tr:last-child th {
+	border-bottom: 0;
+}
+
+/* Round the corner cells so their backgrounds don't poke past the radius */
+.ProseMirror table tr:first-child th:first-child,
+.ProseMirror table tr:first-child td:first-child {
+	border-top-left-radius: calc(var(--corner-radius) - 1px);
+}
+
+.ProseMirror table tr:first-child th:last-child,
+.ProseMirror table tr:first-child td:last-child {
+	border-top-right-radius: calc(var(--corner-radius) - 1px);
+}
+
+.ProseMirror table tr:last-child td:first-child,
+.ProseMirror table tr:last-child th:first-child {
+	border-bottom-left-radius: calc(var(--corner-radius) - 1px);
+}
+
+.ProseMirror table tr:last-child td:last-child,
+.ProseMirror table tr:last-child th:last-child {
+	border-bottom-right-radius: calc(var(--corner-radius) - 1px);
 }
 
 .ProseMirror table td:first-of-type:not(a),
@@ -551,7 +595,10 @@ ul[data-type='taskList'] li[data-checked='true'] div {
 }
 
 .tiptap iframe {
+	width: 100%;
 	aspect-ratio: 16 / 9;
+	border: 0;
+	border-radius: var(--corner-radius);
 }
 
 /* Mathematics extension styles */

--- a/src/lib/components/edra/headless/components/GalleryExtended.svelte
+++ b/src/lib/components/edra/headless/components/GalleryExtended.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
 	import { NodeViewWrapper } from 'svelte-tiptap'
 	import type { NodeViewProps } from '@tiptap/core'
+	import tippy, { type Instance } from 'tippy.js'
+	import 'tippy.js/dist/tippy.css'
 	import Grid from '@lucide/svelte/icons/grid-3x3'
 	import Columns from '@lucide/svelte/icons/columns'
+	import RectangleVertical from '@lucide/svelte/icons/rectangle-vertical'
+	import Columns2 from '@lucide/svelte/icons/columns-2'
+	import Columns3 from '@lucide/svelte/icons/columns-3'
 	import Trash from '@lucide/svelte/icons/trash'
 	import Edit from '@lucide/svelte/icons/edit'
 	import Plus from '@lucide/svelte/icons/plus'
@@ -13,6 +18,57 @@
 
 	let isMediaLibraryOpen = $state(false)
 	let editingMode = $state(false)
+
+	// Hover toolbar (same pattern as MediaExtended) — controls must never sit
+	// in the content flow since they don't exist on the published page
+	let groupRef = $state<HTMLElement>()
+	let toolbarRef = $state<HTMLElement>()
+	let tippyInstance: Instance | undefined
+
+	$effect(() => {
+		if (!groupRef || !toolbarRef || !editor?.isEditable) {
+			tippyInstance?.destroy()
+			tippyInstance = undefined
+			return
+		}
+
+		tippyInstance = tippy(groupRef, {
+			content: toolbarRef,
+			interactive: true,
+			trigger: 'mouseenter',
+			placement: 'top-end',
+			appendTo: () => document.body,
+			arrow: false,
+			theme: 'media-toolbar',
+			delay: [100, 300],
+			offset: [0, 8],
+			interactiveBorder: 20,
+			zIndex: 200,
+			popperOptions: {
+				modifiers: [
+					{
+						name: 'preventOverflow',
+						options: { boundary: 'viewport', padding: 8 }
+					},
+					{
+						name: 'flip',
+						options: {
+							fallbackPlacements: ['bottom-end', 'top-start', 'bottom-start']
+						}
+					}
+				]
+			}
+		})
+
+		return () => {
+			tippyInstance?.destroy()
+			tippyInstance = undefined
+		}
+	})
+
+	$effect(() => {
+		if (selected && tippyInstance) tippyInstance.show()
+	})
 
 	function handleEditGallery() {
 		editingMode = true
@@ -80,7 +136,7 @@
 	data-layout={layout}
 	style={`--columns: ${columns}`}
 >
-	<div class="edra-gallery-content">
+	<div bind:this={groupRef} class="edra-gallery-content">
 		{#if images.length === 0}
 			<div class="edra-gallery-empty">
 				<Grid class="edra-gallery-empty-icon" />
@@ -106,53 +162,58 @@
 		{/if}
 
 		{#if editor?.isEditable}
-			<div class="edra-gallery-toolbar">
-				<div class="edra-gallery-toolbar-section">
-					<button
-						class={`edra-toolbar-button ${layout === 'grid' ? 'active' : ''}`}
-						onclick={() => changeLayout('grid')}
-						title="Grid Layout"
-					>
-						<Grid />
-					</button>
-					<button
-						class={`edra-toolbar-button ${layout === 'masonry' ? 'active' : ''}`}
-						onclick={() => changeLayout('masonry')}
-						title="Masonry Layout"
-					>
-						<Columns />
-					</button>
-				</div>
-
-				<div class="edra-gallery-toolbar-section">
-					<select
-						class="edra-gallery-columns-select"
-						value={columns}
-						onchange={(e) => changeColumns(parseInt(e.currentTarget.value))}
-						title="Columns"
-					>
-						<option value="2">2 cols</option>
-						<option value="3">3 cols</option>
-						<option value="4">4 cols</option>
-						<option value="5">5 cols</option>
-					</select>
-				</div>
-
-				<div class="edra-gallery-toolbar-section">
-					<button class="edra-toolbar-button" onclick={handleAddImages} title="Add Images">
-						<Plus />
-					</button>
-					<button class="edra-toolbar-button" onclick={handleEditGallery} title="Edit Gallery">
-						<Edit />
-					</button>
-					<button
-						class="edra-toolbar-button edra-destructive"
-						onclick={() => deleteNode()}
-						title="Delete Gallery"
-					>
-						<Trash />
-					</button>
-				</div>
+			<div bind:this={toolbarRef} class="edra-media-toolbar">
+				<button
+					class={`edra-toolbar-button ${layout === 'grid' ? 'active' : ''}`}
+					onclick={() => changeLayout('grid')}
+					title="Grid Layout"
+				>
+					<Grid />
+				</button>
+				<button
+					class={`edra-toolbar-button ${layout === 'masonry' ? 'active' : ''}`}
+					onclick={() => changeLayout('masonry')}
+					title="Masonry Layout"
+				>
+					<Columns />
+				</button>
+				<div class="edra-toolbar-divider"></div>
+				<button
+					class={`edra-toolbar-button ${columns === 1 ? 'active' : ''}`}
+					onclick={() => changeColumns(1)}
+					title="1 column"
+				>
+					<RectangleVertical />
+				</button>
+				<button
+					class={`edra-toolbar-button ${columns === 2 ? 'active' : ''}`}
+					onclick={() => changeColumns(2)}
+					title="2 columns"
+				>
+					<Columns2 />
+				</button>
+				<button
+					class={`edra-toolbar-button ${columns === 3 ? 'active' : ''}`}
+					onclick={() => changeColumns(3)}
+					title="3 columns"
+				>
+					<Columns3 />
+				</button>
+				<div class="edra-toolbar-divider"></div>
+				<button class="edra-toolbar-button" onclick={handleAddImages} title="Add Images">
+					<Plus />
+				</button>
+				<button class="edra-toolbar-button" onclick={handleEditGallery} title="Edit Gallery">
+					<Edit />
+				</button>
+				<div class="edra-toolbar-divider"></div>
+				<button
+					class="edra-toolbar-button edra-destructive"
+					onclick={() => deleteNode()}
+					title="Delete Gallery"
+				>
+					<Trash />
+				</button>
 			</div>
 		{/if}
 	</div>
@@ -211,7 +272,17 @@
 		grid-template-columns: repeat(var(--columns), 1fr);
 	}
 
+	// In grid view, cells share a row height — fill them edge to edge like the
+	// published page does (object-fit: cover), cropping centered rather than
+	// letterboxing shorter images
+	.edra-gallery-grid.grid .edra-gallery-item img {
+		height: 100%;
+		object-fit: cover;
+	}
+
 	.edra-gallery-grid.masonry {
+		// column-count needs block layout; the base class is display: grid
+		display: block;
 		column-count: var(--columns);
 		column-gap: $unit;
 	}
@@ -267,38 +338,6 @@
 		height: $unit-12px;
 	}
 
-	.edra-gallery-toolbar {
-		display: flex;
-		align-items: center;
-		gap: $unit-12px;
-		padding: $unit;
-		background: rgba(255, 255, 255, 0.95);
-		border: $unit-1px solid #e5e7eb;
-		border-radius: $corner-radius-sm;
-		margin-top: $unit;
-		backdrop-filter: blur($unit-half);
-	}
-
-	.edra-gallery-toolbar-section {
-		display: flex;
-		align-items: center;
-		gap: $unit-half;
-	}
-
-	.edra-gallery-columns-select {
-		padding: $unit-half $unit;
-		border: $unit-1px solid #e5e7eb;
-		border-radius: $corner-radius-xs;
-		background: white;
-		font-size: $unit-12px;
-		cursor: pointer;
-	}
-
-	.edra-gallery-columns-select:focus {
-		outline: none;
-		border-color: #3b82f6;
-	}
-
 	:global(.edra-toolbar-button) {
 		display: flex;
 		align-items: center;
@@ -333,11 +372,11 @@
 
 	@media (max-width: 768px) {
 		.edra-gallery-grid.grid {
-			grid-template-columns: repeat(2, 1fr);
+			grid-template-columns: repeat(min(var(--columns), 2), 1fr);
 		}
 
 		.edra-gallery-grid.masonry {
-			column-count: 2;
+			column-count: min(var(--columns), 2);
 		}
 	}
 </style>

--- a/src/lib/components/edra/headless/components/GeolocationExtended.svelte
+++ b/src/lib/components/edra/headless/components/GeolocationExtended.svelte
@@ -4,14 +4,82 @@
 	import { onMount } from 'svelte'
 	import { mount, unmount } from 'svelte'
 	import type L from 'leaflet'
+	import tippy, { type Instance } from 'tippy.js'
+	import 'tippy.js/dist/tippy.css'
+	import Edit from '@lucide/svelte/icons/edit'
+	import CopyIcon from '@lucide/svelte/icons/copy'
+	import Trash from '@lucide/svelte/icons/trash'
 	import MapPopup from './MapPopup.svelte'
+	import { duplicateContent } from '../../utils.js'
 
 	type Props = NodeViewProps
-	let { node, selected }: Props = $props()
+	let { node, editor, selected, deleteNode, getPos }: Props = $props()
 
 	let mapContainer: HTMLDivElement
 	let map: L.Map | null = null
 	let leaflet: typeof L
+
+	// Hover toolbar (same pattern as MediaExtended/GalleryExtended)
+	let groupRef = $state<HTMLElement>()
+	let toolbarRef = $state<HTMLElement>()
+	let tippyInstance: Instance | undefined
+
+	$effect(() => {
+		if (!groupRef || !toolbarRef || !editor?.isEditable) {
+			tippyInstance?.destroy()
+			tippyInstance = undefined
+			return
+		}
+
+		tippyInstance = tippy(groupRef, {
+			content: toolbarRef,
+			interactive: true,
+			trigger: 'mouseenter',
+			placement: 'top-end',
+			appendTo: () => document.body,
+			arrow: false,
+			theme: 'media-toolbar',
+			delay: [100, 300],
+			offset: [0, 8],
+			interactiveBorder: 20,
+			zIndex: 200,
+			popperOptions: {
+				modifiers: [
+					{
+						name: 'preventOverflow',
+						options: { boundary: 'viewport', padding: 8 }
+					},
+					{
+						name: 'flip',
+						options: {
+							fallbackPlacements: ['bottom-end', 'top-start', 'bottom-start']
+						}
+					}
+				]
+			}
+		})
+
+		return () => {
+			tippyInstance?.destroy()
+			tippyInstance = undefined
+		}
+	})
+
+	$effect(() => {
+		if (selected && tippyInstance) tippyInstance.show()
+	})
+
+	// Swap the node back to a placeholder so the location picker reopens
+	function changeLocation() {
+		const pos = getPos?.()
+		if (typeof pos !== 'number') return
+		editor
+			.chain()
+			.focus()
+			.deleteRange({ from: pos, to: pos + node.nodeSize })
+			.insertContentAt(pos, { type: 'geolocation-placeholder' })
+			.run()
+	}
 
 	const latitude = node.attrs.latitude as number
 	const longitude = node.attrs.longitude as number
@@ -74,8 +142,31 @@
 </script>
 
 <NodeViewWrapper>
-	<div class="geolocation-node" class:selected>
+	<div bind:this={groupRef} class="geolocation-node" class:selected>
 		<div bind:this={mapContainer} class="map-container"></div>
+
+		{#if editor?.isEditable}
+			<div bind:this={toolbarRef} class="edra-media-toolbar">
+				<button class="edra-toolbar-button" onclick={changeLocation} title="Change location">
+					<Edit size={16} strokeWidth={2} />
+				</button>
+				<button
+					class="edra-toolbar-button"
+					onclick={() => duplicateContent(editor, node)}
+					title="Duplicate"
+				>
+					<CopyIcon size={16} strokeWidth={2} />
+				</button>
+				<div class="edra-toolbar-divider"></div>
+				<button
+					class="edra-toolbar-button edra-destructive"
+					onclick={() => deleteNode()}
+					title="Delete"
+				>
+					<Trash size={16} strokeWidth={2} />
+				</button>
+			</div>
+		{/if}
 	</div>
 </NodeViewWrapper>
 
@@ -91,7 +182,7 @@
 
 	.geolocation-node {
 		margin: 16px 0;
-		border-radius: 8px;
+		border-radius: var(--corner-radius);
 		overflow: hidden;
 		border: 2px solid transparent;
 		transition: border-color 0.2s;

--- a/src/lib/components/edra/headless/components/MediaExtended.svelte
+++ b/src/lib/components/edra/headless/components/MediaExtended.svelte
@@ -328,6 +328,7 @@
 				>
 					<Accessibility size={16} strokeWidth={2} />
 				</button>
+				<div class="edra-toolbar-divider"></div>
 				<button
 					class="edra-toolbar-button"
 					onclick={() => {
@@ -348,6 +349,7 @@
 				>
 					<Fullscreen size={16} strokeWidth={2} />
 				</button>
+				<div class="edra-toolbar-divider"></div>
 				<button
 					class="edra-toolbar-button edra-destructive"
 					onclick={() => {

--- a/src/lib/components/edra/headless/style.css
+++ b/src/lib/components/edra/headless/style.css
@@ -110,6 +110,7 @@
 .edra-media-container video {
 	max-width: 100%;
 	height: auto;
+	border-radius: var(--corner-radius);
 }
 
 .edra-media-container.selected {
@@ -189,6 +190,14 @@
 	-webkit-backdrop-filter: blur(12px);
 	box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
 	padding: 4px;
+}
+
+.edra-toolbar-divider {
+	width: 1px;
+	height: 16px;
+	background: rgba(0, 0, 0, 0.1);
+	margin: 0 4px;
+	flex-shrink: 0;
 }
 
 .tippy-box[data-theme~='media-toolbar'] {


### PR DESCRIPTION
## Summary

Stacked on #96 (base branch: `edra-content-fixes` — retarget to `main` once that merges). Design/UX polish round for the editor, in three scoped commits:

**1. Editor/public visual parity + shape token**
- New `--corner-radius` CSS variable in `themes.scss` bridging the `$corner-radius` SCSS token to plain-CSS consumers (the Edra stylesheets). Tables, maps, iframes, and solo images all read it now — change the token once, everything reshapes, editor and public alike.
- h3–h6 get `margin-bottom` in the editor (they only had top margin — broken vertical rhythm).
- Editor tables now render exactly like published ones: full width, rounded outer border, inner dividers only, header background. (`border-collapse: separate` is what lets radius render; the wrapper carves out a negative-margin gutter so the hover grip handles keep their room.)
- Public solo images unified from 8px to the 16px token (posts + case studies).
- Divider element styling for the hover toolbars, applied to the image/video/audio toolbar's groups.

**2. Gallery UX**
- Controls moved from in-flow below the grid into the same tippy hover toolbar the other media nodes use — nothing renders in the content flow that doesn't publish.
- Column count is now three icon buttons (1/2/3) instead of a 2–5 dropdown; mobile fallbacks use `min(columns, 2)` so 1-column galleries stay single-column.
- Fixed masonry doing nothing (base class forced `display: grid`, making `column-count` a no-op) and added public masonry styles (previously published as a plain grid).
- Grid cells fill with `object-fit: cover` like the published page; fixed the columns control not reflecting the current value (Svelte 5 strict select matching, number vs string).

**3. Location node**
- Had zero controls. Now has the same hover toolbar: **Change location** (atomically swaps back to the picker placeholder at the same position), **Duplicate**, **Delete**. Map corners use the shared token.

All verified live against the running editor: toolbars raise on hover/selection with correct grouping and active states, masonry flips to CSS columns, grid cells cover, change-location round-trips to the picker, zero console errors, svelte-check baseline unchanged (111 pre-existing).

## Test plan

- [ ] Insert a table — full width, rounded, matches the published render side by side
- [ ] Hover image/gallery/location nodes — consistent toolbars with dividers; no in-flow controls anywhere
- [ ] Gallery: toggle 1/2/3 columns and grid/masonry with mixed-aspect images; publish and compare
- [ ] Location: Change location reopens the picker in place
- [ ] Nudge `$corner-radius` locally and confirm tables/maps/iframes/images all follow